### PR TITLE
러너 게시글 등록 API 구현

### DIFF
--- a/backend/baton/src/main/java/touch/baton/domain/common/vo/ChattingRoomCount.java
+++ b/backend/baton/src/main/java/touch/baton/domain/common/vo/ChattingRoomCount.java
@@ -16,6 +16,7 @@ import static lombok.AccessLevel.PROTECTED;
 public class ChattingRoomCount {
 
     private static final String DEFAULT_VALUE = "0";
+    private static final ChattingRoomCount ZERO = new ChattingRoomCount(Integer.parseInt(DEFAULT_VALUE));
 
     @ColumnDefault(DEFAULT_VALUE)
     @Column(name = "chatting_room_count", nullable = false)
@@ -23,5 +24,9 @@ public class ChattingRoomCount {
 
     public ChattingRoomCount(final int value) {
         this.value = value;
+    }
+
+    public static ChattingRoomCount zero() {
+        return ZERO;
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/common/vo/ChattingRoomCount.java
+++ b/backend/baton/src/main/java/touch/baton/domain/common/vo/ChattingRoomCount.java
@@ -2,12 +2,14 @@ package touch.baton.domain.common.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 import static lombok.AccessLevel.PROTECTED;
 
+@EqualsAndHashCode
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Embeddable

--- a/backend/baton/src/main/java/touch/baton/domain/common/vo/Contents.java
+++ b/backend/baton/src/main/java/touch/baton/domain/common/vo/Contents.java
@@ -2,6 +2,7 @@ package touch.baton.domain.common.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import java.util.Objects;
 
 import static lombok.AccessLevel.PROTECTED;
 
+@EqualsAndHashCode
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Embeddable

--- a/backend/baton/src/main/java/touch/baton/domain/common/vo/Title.java
+++ b/backend/baton/src/main/java/touch/baton/domain/common/vo/Title.java
@@ -2,6 +2,7 @@ package touch.baton.domain.common.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import java.util.Objects;
 
 import static lombok.AccessLevel.PROTECTED;
 
+@EqualsAndHashCode
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Embeddable

--- a/backend/baton/src/main/java/touch/baton/domain/common/vo/WatchedCount.java
+++ b/backend/baton/src/main/java/touch/baton/domain/common/vo/WatchedCount.java
@@ -2,12 +2,14 @@ package touch.baton.domain.common.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 import static lombok.AccessLevel.PROTECTED;
 
+@EqualsAndHashCode
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Embeddable

--- a/backend/baton/src/main/java/touch/baton/domain/common/vo/WatchedCount.java
+++ b/backend/baton/src/main/java/touch/baton/domain/common/vo/WatchedCount.java
@@ -16,6 +16,7 @@ import static lombok.AccessLevel.PROTECTED;
 public class WatchedCount {
 
     private static final String DEFAULT_VALUE = "0";
+    private static final WatchedCount ZERO = new WatchedCount(Integer.parseInt(DEFAULT_VALUE));
 
     @ColumnDefault(DEFAULT_VALUE)
     @Column(name = "watch_count", nullable = false)
@@ -23,5 +24,9 @@ public class WatchedCount {
 
     public WatchedCount(final int value) {
         this.value = value;
+    }
+
+    public static WatchedCount zero() {
+        return ZERO;
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runner/exception/RunnerException.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runner/exception/RunnerException.java
@@ -14,4 +14,11 @@ public class RunnerException extends DomainException {
             super(message);
         }
     }
+
+    public static class NotFound extends RunnerException {
+
+        public NotFound(final String message) {
+            super(message);
+        }
+    }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runner/repository/RunnerRepository.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runner/repository/RunnerRepository.java
@@ -1,7 +1,19 @@
 package touch.baton.domain.runner.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import touch.baton.domain.runner.Runner;
 
+import java.util.Optional;
+
 public interface RunnerRepository extends JpaRepository<Runner, Long> {
+
+    @Query("""
+            select r
+            from Runner r
+            join fetch Member m on m.id = r.id
+            where r.id = :runnerId
+            """)
+    Optional<Runner> findByIdJoinMember(@Param("runnerId") Long runnerId);
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runner/service/RunnerService.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runner/service/RunnerService.java
@@ -1,0 +1,21 @@
+package touch.baton.domain.runner.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.exception.RunnerException;
+import touch.baton.domain.runner.repository.RunnerRepository;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class RunnerService {
+
+    private final RunnerRepository runnerRepository;
+
+    public Runner readRunnerWithMember(final Long runnerId) {
+        return runnerRepository.findByIdJoinMember(runnerId)
+                .orElseThrow(() -> new RunnerException.NotFound("해당하는 식별자의 Runner 를 찾을 수 없습니다."));
+    }
+}

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/RunnerPost.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/RunnerPost.java
@@ -21,8 +21,11 @@ import touch.baton.domain.runnerpost.exception.RunnerPostException;
 import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.PullRequestUrl;
 import touch.baton.domain.supporter.Supporter;
+import touch.baton.domain.tag.RunnerPostTag;
 import touch.baton.domain.tag.RunnerPostTags;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Objects;
 
 import static jakarta.persistence.FetchType.LAZY;
@@ -82,15 +85,15 @@ public class RunnerPost extends BaseEntity {
     }
 
     private RunnerPost(final Long id,
-                      final Title title,
-                      final Contents contents,
-                      final PullRequestUrl pullRequestUrl,
-                      final Deadline deadline,
-                      final WatchedCount watchedCount,
-                      final ChattingRoomCount chattingRoomCount,
-                      final Runner runner,
-                      final Supporter supporter,
-                      final RunnerPostTags runnerPostTags
+                       final Title title,
+                       final Contents contents,
+                       final PullRequestUrl pullRequestUrl,
+                       final Deadline deadline,
+                       final WatchedCount watchedCount,
+                       final ChattingRoomCount chattingRoomCount,
+                       final Runner runner,
+                       final Supporter supporter,
+                       final RunnerPostTags runnerPostTags
     ) {
         validateNotNull(title, contents, pullRequestUrl, deadline, watchedCount, chattingRoomCount, runner, runnerPostTags);
         this.id = id;
@@ -145,5 +148,27 @@ public class RunnerPost extends BaseEntity {
         if (Objects.isNull(runnerPostTags)) {
             throw new RunnerPostException.NotNull("runnerPostTags 는 null 일 수 없습니다.");
         }
+    }
+
+    public static RunnerPost newInstance(final String title,
+                                         final String contents,
+                                         final String pullRequestUrl,
+                                         final LocalDateTime deadline,
+                                         final Runner runner
+    ) {
+        return RunnerPost.builder()
+                .title(new Title(title))
+                .contents(new Contents(contents))
+                .pullRequestUrl(new PullRequestUrl(pullRequestUrl))
+                .deadline(new Deadline(deadline))
+                .runner(runner)
+                .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
+                .watchedCount(WatchedCount.zero())
+                .chattingRoomCount(ChattingRoomCount.zero())
+                .build();
+    }
+
+    public void addPostTag(final RunnerPostTag postTag) {
+        runnerPostTags.add(postTag);
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/RunnerPost.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/RunnerPost.java
@@ -26,6 +26,7 @@ import touch.baton.domain.tag.RunnerPostTags;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import static jakarta.persistence.FetchType.LAZY;
@@ -168,7 +169,7 @@ public class RunnerPost extends BaseEntity {
                 .build();
     }
 
-    public void addPostTag(final RunnerPostTag postTag) {
-        runnerPostTags.add(postTag);
+    public void addAllRunnerPostTags(final List<RunnerPostTag> postTags) {
+        runnerPostTags.addAll(postTags);
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/RunnerPostController.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/RunnerPostController.java
@@ -1,9 +1,18 @@
 package touch.baton.domain.runnerpost.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.service.RunnerService;
 import touch.baton.domain.runnerpost.service.RunnerPostService;
+import touch.baton.domain.runnerpost.service.dto.RunnerPostCreateRequest;
+
+import java.net.URI;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/posts/runner")
@@ -11,4 +20,18 @@ import touch.baton.domain.runnerpost.service.RunnerPostService;
 public class RunnerPostController {
 
     private final RunnerPostService runnerPostService;
+    private final RunnerService runnerService;
+
+    @PostMapping
+    public ResponseEntity<Void> createRunnerPost(@RequestBody RunnerPostCreateRequest request) {
+        // TODO 07/19 로그인 기능 개발시 1L 변경 요망
+        Runner runner = runnerService.readRunnerWithMember(1L);
+        final Long saveId = runnerPostService.create(runner, request);
+
+        final URI redirectUri = UriComponentsBuilder.fromPath("/api/v1/posts/runner")
+                .path("/{id}")
+                .buildAndExpand(saveId)
+                .toUri();
+        return ResponseEntity.created(redirectUri).build();
+    }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/service/RunnerPostService.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/service/RunnerPostService.java
@@ -3,7 +3,16 @@ package touch.baton.domain.runnerpost.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.repository.RunnerPostRepository;
+import touch.baton.domain.runnerpost.service.dto.RunnerPostCreateRequest;
+import touch.baton.domain.tag.RunnerPostTag;
+import touch.baton.domain.tag.Tag;
+import touch.baton.domain.tag.repository.TagRepository;
+
+import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -11,5 +20,49 @@ import touch.baton.domain.runnerpost.repository.RunnerPostRepository;
 public class RunnerPostService {
 
     private final RunnerPostRepository runnerPostRepository;
+    private final TagRepository tagRepository;
 
+    @Transactional
+    public Long create(final Runner runner, final RunnerPostCreateRequest request) {
+        RunnerPost runnerPost = toDomain(runner, request);
+
+        final List<Tag> tags = request.tags().stream()
+                .map(Tag::newInstance)
+                .toList();
+
+        for (final Tag tag : tags) {
+            final Optional<Tag> findTag = tagRepository.findByTagName(tag.getTagName());
+
+            if (findTag.isEmpty()) {
+                tagRepository.save(tag);
+                continue;
+            }
+
+            final Tag presentTag = findTag.get();
+            presentTag.increaseCount();
+        }
+
+        runnerPostRepository.save(runnerPost);
+
+        final List<RunnerPostTag> postTags = tags.stream()
+                .map(tag -> RunnerPostTag.builder()
+                        .tag(tag)
+                        .runnerPost(runnerPost)
+                        .build())
+                .toList();
+
+        for (final RunnerPostTag postTag : postTags) {
+            runnerPost.addPostTag(postTag);
+        }
+
+        return runnerPost.getId();
+    }
+
+    private RunnerPost toDomain(final Runner runner, final RunnerPostCreateRequest request) {
+        return RunnerPost.newInstance(request.title(),
+                request.contents(),
+                request.pullRequestUrl(),
+                request.deadline(),
+                runner);
+    }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/service/RunnerPostService.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/service/RunnerPostService.java
@@ -51,9 +51,7 @@ public class RunnerPostService {
                         .build())
                 .toList();
 
-        for (final RunnerPostTag postTag : postTags) {
-            runnerPost.addPostTag(postTag);
-        }
+        runnerPost.addAllRunnerPostTags(postTags);
 
         return runnerPost.getId();
     }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/service/RunnerPostService.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/service/RunnerPostService.java
@@ -52,7 +52,6 @@ public class RunnerPostService {
                 .toList();
 
         runnerPost.addAllRunnerPostTags(postTags);
-
         return runnerPost.getId();
     }
 

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/service/dto/RunnerPostCreateRequest.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/service/dto/RunnerPostCreateRequest.java
@@ -1,0 +1,15 @@
+package touch.baton.domain.runnerpost.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record RunnerPostCreateRequest(String title,
+                                      List<String> tags,
+                                      String pullRequestUrl,
+                                      @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+                                LocalDateTime deadline,
+                                      String contents
+) {
+}

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/Deadline.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/Deadline.java
@@ -2,6 +2,7 @@ package touch.baton.domain.runnerpost.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -11,6 +12,7 @@ import java.util.Objects;
 
 import static lombok.AccessLevel.PROTECTED;
 
+@EqualsAndHashCode
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Embeddable

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/PullRequestUrl.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/PullRequestUrl.java
@@ -2,6 +2,7 @@ package touch.baton.domain.runnerpost.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import java.util.Objects;
 
 import static lombok.AccessLevel.PROTECTED;
 
+@EqualsAndHashCode
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Embeddable

--- a/backend/baton/src/main/java/touch/baton/domain/tag/RunnerPostTag.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/RunnerPostTag.java
@@ -55,11 +55,4 @@ public class RunnerPostTag {
             throw new TagException.NotNull("tag 은 null 일 수 없습니다.");
         }
     }
-
-    public static RunnerPostTag create(final RunnerPost runnerPost, final Tag tag) {
-        return RunnerPostTag.builder()
-                .runnerPost(runnerPost)
-                .tag(tag)
-                .build();
-    }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/tag/RunnerPostTag.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/RunnerPostTag.java
@@ -55,4 +55,11 @@ public class RunnerPostTag {
             throw new TagException.NotNull("tag 은 null 일 수 없습니다.");
         }
     }
+
+    public static RunnerPostTag create(final RunnerPost runnerPost, final Tag tag) {
+        return RunnerPostTag.builder()
+                .runnerPost(runnerPost)
+                .tag(tag)
+                .build();
+    }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/tag/RunnerPostTags.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/RunnerPostTags.java
@@ -23,7 +23,7 @@ public class RunnerPostTags {
         this.runnerPostTags = runnerPostTags;
     }
 
-    public void add(final RunnerPostTag postTag) {
-        runnerPostTags.add(postTag);
+    public void addAll(final List<RunnerPostTag> runnerPostTags) {
+        this.runnerPostTags.addAll(runnerPostTags);
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/tag/RunnerPostTags.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/RunnerPostTags.java
@@ -22,4 +22,8 @@ public class RunnerPostTags {
     public RunnerPostTags(final List<RunnerPostTag> runnerPostTags) {
         this.runnerPostTags = runnerPostTags;
     }
+
+    public void add(final RunnerPostTag postTag) {
+        runnerPostTags.add(postTag);
+    }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/tag/Tag.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/Tag.java
@@ -52,4 +52,15 @@ public class Tag {
             throw new TagException.NotNull("tagCount 은 null 일 수 없습니다.");
         }
     }
+
+    public static Tag newInstance(final String tagName) {
+        return Tag.builder()
+                .tagName(new TagName(tagName))
+                .tagCount(TagCount.zero())
+                .build();
+    }
+
+    public void increaseCount() {
+        this.tagCount = tagCount.increase();
+    }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/tag/Tag.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/Tag.java
@@ -56,7 +56,7 @@ public class Tag {
     public static Tag newInstance(final String tagName) {
         return Tag.builder()
                 .tagName(new TagName(tagName))
-                .tagCount(TagCount.zero())
+                .tagCount(TagCount.initial())
                 .build();
     }
 

--- a/backend/baton/src/main/java/touch/baton/domain/tag/Tag.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/Tag.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import touch.baton.domain.common.BaseEntity;
 import touch.baton.domain.tag.exception.TagException;
 import touch.baton.domain.tag.vo.TagCount;
 import touch.baton.domain.tag.vo.TagName;
@@ -20,7 +19,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Entity
-public class Tag extends BaseEntity {
+public class Tag {
 
     @GeneratedValue(strategy = IDENTITY)
     @Id

--- a/backend/baton/src/main/java/touch/baton/domain/tag/repository/TagRepository.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/repository/TagRepository.java
@@ -2,6 +2,11 @@ package touch.baton.domain.tag.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import touch.baton.domain.tag.Tag;
+import touch.baton.domain.tag.vo.TagName;
+
+import java.util.Optional;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    Optional<Tag> findByTagName(final TagName tagName);
 }

--- a/backend/baton/src/main/java/touch/baton/domain/tag/vo/TagCount.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/vo/TagCount.java
@@ -26,7 +26,7 @@ public class TagCount {
         this.value = value;
     }
 
-    public static TagCount zero() {
+    public static TagCount initial() {
         return INITIAL_TAG_COUNT;
     }
 

--- a/backend/baton/src/main/java/touch/baton/domain/tag/vo/TagCount.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/vo/TagCount.java
@@ -2,18 +2,21 @@ package touch.baton.domain.tag.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 import static lombok.AccessLevel.PROTECTED;
 
+@EqualsAndHashCode
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Embeddable
 public class TagCount {
 
     private static final String DEFAULT_VALUE = "1";
+    private static final TagCount INITIAL_TAG_COUNT = new TagCount(Integer.parseInt(DEFAULT_VALUE));
 
     @ColumnDefault(DEFAULT_VALUE)
     @Column(name = "tag_count", nullable = false)
@@ -21,5 +24,13 @@ public class TagCount {
 
     public TagCount(final int value) {
         this.value = value;
+    }
+
+    public static TagCount zero() {
+        return INITIAL_TAG_COUNT;
+    }
+
+    public TagCount increase() {
+        return new TagCount(value + 1);
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/tag/vo/TagName.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/vo/TagName.java
@@ -2,6 +2,7 @@ package touch.baton.domain.tag.vo;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import java.util.Objects;
 
 import static lombok.AccessLevel.PROTECTED;
 
+@EqualsAndHashCode
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Embeddable

--- a/backend/baton/src/main/java/touch/baton/domain/tag/vo/TagName.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/vo/TagName.java
@@ -14,7 +14,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Embeddable
 public class TagName {
 
-    @Column(name = "name", nullable = false)
+    @Column(name = "name", nullable = false, unique = true)
     private String  value;
 
     public TagName(final String value) {

--- a/backend/baton/src/test/java/touch/baton/domain/common/vo/ChattingRoomCountTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/common/vo/ChattingRoomCountTest.java
@@ -1,0 +1,19 @@
+package touch.baton.domain.common.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChattingRoomCountTest {
+
+    @DisplayName("기본 채팅수를 가진 ChattingRoomCount 를 생성할 수 있다.")
+    @Test
+    void createDefaultChattingRoomCount() {
+        // given
+        final ChattingRoomCount expected = ChattingRoomCount.zero();
+
+        // when, then
+        assertThat(expected.getValue()).isEqualTo(0);
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/domain/common/vo/WatchedCountTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/common/vo/WatchedCountTest.java
@@ -1,0 +1,19 @@
+package touch.baton.domain.common.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WatchedCountTest {
+    
+    @DisplayName("기본 조회수를 가진 WatchedCount 를 생성할 수 있다.")
+    @Test
+    void createDefaultWatchedCount() {
+        // given
+        final WatchedCount expected = WatchedCount.zero();
+
+        // when, then
+        assertThat(expected.getValue()).isEqualTo(0);
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/domain/runner/repository/RunnerRepositoryTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runner/repository/RunnerRepositoryTest.java
@@ -1,0 +1,96 @@
+package touch.baton.domain.runner.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import touch.baton.config.JpaConfig;
+import touch.baton.domain.common.vo.Grade;
+import touch.baton.domain.common.vo.TotalRating;
+import touch.baton.domain.member.Member;
+import touch.baton.domain.member.repository.MemberRepository;
+import touch.baton.domain.member.vo.Company;
+import touch.baton.domain.member.vo.Email;
+import touch.baton.domain.member.vo.GithubUrl;
+import touch.baton.domain.member.vo.MemberName;
+import touch.baton.domain.member.vo.OauthId;
+import touch.baton.domain.runner.Runner;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Import(JpaConfig.class)
+@DataJpaTest
+class RunnerRepositoryTest {
+
+    private static final MemberName memberName = new MemberName("헤에디주");
+    private static final Email email = new Email("test@test.co.kr");
+    private static final OauthId oauthId = new OauthId("dsigjh98gh230gn2oinv913bcuo23nqovbvu93b12voi3bc31j");
+    private static final GithubUrl githubUrl = new GithubUrl("github.com/hyena0608");
+    private static final Company company = new Company("우아한형제들");
+    private static final TotalRating totalRating = new TotalRating(100);
+    private static final Grade grade = Grade.BARE_FOOT;
+
+    @Autowired
+    private RunnerRepository runnerRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+    private Runner runner;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .memberName(memberName)
+                .email(email)
+                .oauthId(oauthId)
+                .githubUrl(githubUrl)
+                .company(company)
+                .build();
+        memberRepository.save(member);
+
+        runner = Runner.builder()
+                .totalRating(totalRating)
+                .grade(grade)
+                .member(member)
+                .build();
+    }
+
+    @DisplayName("Runner 를 Member 와 조인해서 조회할 수 있다.")
+    @Test
+    void findByIdJoinMember() {
+        // given
+        final Runner expected = runnerRepository.save(runner);
+
+        // when
+        final Optional<Runner> actual = runnerRepository.findByIdJoinMember(expected.getId());
+
+        // then
+        assertThat(actual).isPresent();
+        final Member actualMember = actual.get().getMember();
+        assertAll(
+                () -> assertThat(actualMember.getId()).isNotNull(),
+                () -> assertThat(actualMember.getMemberName()).isEqualTo(memberName),
+                () -> assertThat(actualMember.getCompany()).isEqualTo(company),
+                () -> assertThat(actualMember.getEmail()).isEqualTo(email),
+                () -> assertThat(actualMember.getOauthId()).isEqualTo(oauthId),
+                () -> assertThat(actualMember.getGithubUrl()).isEqualTo(githubUrl)
+        );
+    }
+
+    @DisplayName("식별자가 없으면 Optional.empty()가 반환된다.")
+    @Test
+    void findByIdJoinMember_if_id_is_not_exists() {
+        // when
+        final Optional<Runner> actual = runnerRepository.findByIdJoinMember(999L);
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/domain/runner/service/RunnerServiceReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runner/service/RunnerServiceReadTest.java
@@ -1,0 +1,85 @@
+package touch.baton.domain.runner.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import touch.baton.config.JpaConfig;
+import touch.baton.domain.common.vo.Grade;
+import touch.baton.domain.common.vo.TotalRating;
+import touch.baton.domain.member.Member;
+import touch.baton.domain.member.repository.MemberRepository;
+import touch.baton.domain.member.vo.Company;
+import touch.baton.domain.member.vo.Email;
+import touch.baton.domain.member.vo.GithubUrl;
+import touch.baton.domain.member.vo.MemberName;
+import touch.baton.domain.member.vo.OauthId;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.exception.RunnerException;
+import touch.baton.domain.runner.repository.RunnerRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Import(JpaConfig.class)
+@DataJpaTest
+class RunnerServiceReadTest {
+
+    private RunnerService runnerService;
+    
+    @Autowired
+    private RunnerRepository runnerRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+    private static final MemberName memberName = new MemberName("헤에디주");
+    private static final Email email = new Email("test@test.co.kr");
+    private static final OauthId oauthId = new OauthId("dsigjh98gh230gn2oinv913bcuo23nqovbvu93b12voi3bc31j");
+    private static final GithubUrl githubUrl = new GithubUrl("github.com/hyena0608");
+    private static final Company company = new Company("우아한형제들");
+    private static final TotalRating totalRating = new TotalRating(100);
+    private static final Grade grade = Grade.BARE_FOOT;
+
+    private Runner runner;
+
+    @BeforeEach
+    void setUp() {
+        runnerService = new RunnerService(runnerRepository);
+
+        final Member member = Member.builder()
+                .memberName(memberName)
+                .email(email)
+                .oauthId(oauthId)
+                .githubUrl(githubUrl)
+                .company(company)
+                .build();
+        memberRepository.save(member);
+
+        runner = Runner.builder()
+                .totalRating(totalRating)
+                .grade(grade)
+                .member(member)
+                .build();
+        runnerRepository.save(runner);
+    }
+
+    @DisplayName("Runner 를 Member 와 조인해서 조회할 수 있다.")
+    @Test
+    void success_readRunnerWithMember() {
+        // when
+        final Runner actual = runnerService.readRunnerWithMember(runner.getId());
+
+        // then
+        assertThat(actual).isEqualTo(runner);
+    }
+
+    @DisplayName("식별자로 Runner 와 Member 를 조인해서 조회할 때, 식별자에 해당하는 데이터가 없으면 예외를 던진다.")
+    @Test
+    void fail_readRunnerWithMember_if_id_is_invalid() {
+        // when, then
+        assertThatThrownBy(() -> runnerService.readRunnerWithMember(999L))
+                .isInstanceOf(RunnerException.NotFound.class);
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/RunnerPostTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/RunnerPostTest.java
@@ -22,10 +22,13 @@ import touch.baton.domain.runnerpost.vo.PullRequestUrl;
 import touch.baton.domain.supporter.Supporter;
 import touch.baton.domain.supporter.vo.ReviewCount;
 import touch.baton.domain.supporter.vo.StarCount;
+import touch.baton.domain.tag.RunnerPostTag;
 import touch.baton.domain.tag.RunnerPostTags;
+import touch.baton.domain.tag.Tag;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -34,39 +37,40 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class RunnerPostTest {
 
+    private final Member runnerMember = Member.builder()
+            .memberName(new MemberName("러너 사용자"))
+            .email(new Email("test@test.co.kr"))
+            .oauthId(new OauthId("ads7821iuqjkrhadsioh1f1r4efsoi3bc31j"))
+            .githubUrl(new GithubUrl("github.com/hyena0608"))
+            .company(new Company("우아한테크코스"))
+            .build();
+
+    private final Member supporterMember = Member.builder()
+            .memberName(new MemberName("서포터 사용자"))
+            .email(new Email("test@test.co.kr"))
+            .oauthId(new OauthId("dsigjh98gh230gn2oinv913bcuo23nqovbvu93b12voi3bc31j"))
+            .githubUrl(new GithubUrl("github.com/pobi"))
+            .company(new Company("우아한형제들"))
+            .build();
+
+    private final Runner runner = Runner.builder()
+            .totalRating(new TotalRating(100))
+            .grade(Grade.BARE_FOOT)
+            .member(runnerMember)
+            .build();
+
+    private final Supporter supporter = Supporter.builder()
+            .reviewCount(new ReviewCount(10))
+            .starCount(new StarCount(10))
+            .totalRating(new TotalRating(100))
+            .grade(Grade.BARE_FOOT)
+            .member(supporterMember)
+            .build();
+
     @DisplayName("생성 테스트")
     @Nested
     class Create {
 
-        private final Member runnerMember = Member.builder()
-                .memberName(new MemberName("러너 사용자"))
-                .email(new Email("test@test.co.kr"))
-                .oauthId(new OauthId("ads7821iuqjkrhadsioh1f1r4efsoi3bc31j"))
-                .githubUrl(new GithubUrl("github.com/hyena0608"))
-                .company(new Company("우아한테크코스"))
-                .build();
-
-        private final Member supporterMember = Member.builder()
-                .memberName(new MemberName("서포터 사용자"))
-                .email(new Email("test@test.co.kr"))
-                .oauthId(new OauthId("dsigjh98gh230gn2oinv913bcuo23nqovbvu93b12voi3bc31j"))
-                .githubUrl(new GithubUrl("github.com/pobi"))
-                .company(new Company("우아한형제들"))
-                .build();
-
-        private final Runner runner = Runner.builder()
-                .totalRating(new TotalRating(100))
-                .grade(Grade.BARE_FOOT)
-                .member(runnerMember)
-                .build();
-
-        private final Supporter supporter = Supporter.builder()
-                .reviewCount(new ReviewCount(10))
-                .starCount(new StarCount(10))
-                .totalRating(new TotalRating(100))
-                .grade(Grade.BARE_FOOT)
-                .member(supporterMember)
-                .build();
 
         @DisplayName("성공한다.")
         @Test
@@ -259,5 +263,30 @@ class RunnerPostTest {
                     () -> assertThat(runnerPost.getWatchedCount()).isEqualTo(new WatchedCount(0))
             );
         }
+    }
+    
+    @DisplayName("runnerPostTags 전체를 추가할 수 있다.")
+    @Test
+    void addAllRunnerPostTags() {
+        // given
+        final String title = "JPA 리뷰 부탁 드려요.";
+        final String contents = "넘나 어려워요.";
+        final String pullRequestUrl = "https://github.com/cookienc";
+        final LocalDateTime deadline = LocalDateTime.of(2099, 12, 12, 0, 0);
+        final RunnerPost runnerPost = RunnerPost.newInstance(title, contents, pullRequestUrl, deadline, runner);
+        final RunnerPostTag java = RunnerPostTag.builder()
+                .tag(Tag.newInstance("Java"))
+                .runnerPost(runnerPost)
+                .build();
+        final RunnerPostTag spring = RunnerPostTag.builder()
+                .tag(Tag.newInstance("Spring"))
+                .runnerPost(runnerPost)
+                .build();
+
+        // when
+        runnerPost.addAllRunnerPostTags(List.of(java, spring));
+
+        // then
+        assertThat(runnerPost.getRunnerPostTags().getRunnerPostTags()).hasSize(2);
     }
 }

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/RunnerPostTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/RunnerPostTest.java
@@ -27,8 +27,10 @@ import touch.baton.domain.tag.RunnerPostTags;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class RunnerPostTest {
 
@@ -234,6 +236,28 @@ class RunnerPostTest {
                     .runnerPostTags(null)
                     .build()
             ).isInstanceOf(RunnerPostException.NotNull.class);
+        }
+
+        @DisplayName("태그, 조회수, 채팅수가 초기화된 RunnerPost 를 생성할 수 있다.")
+        @Test
+        void createDefaultRunnerPost() {
+            // given
+            final String title = "JPA 리뷰 부탁 드려요.";
+            final String contents = "넘나 어려워요.";
+            final String pullRequestUrl = "https://github.com/cookienc";
+            final LocalDateTime deadline = LocalDateTime.of(2099, 12, 12, 0, 0);
+            final RunnerPost runnerPost = RunnerPost.newInstance(title, contents, pullRequestUrl, deadline, runner);
+
+            // when, then
+            assertAll(
+                    () -> assertThat(runnerPost.getTitle()).isEqualTo(new Title(title)),
+                    () -> assertThat(runnerPost.getContents()).isEqualTo(new Contents(contents)),
+                    () -> assertThat(runnerPost.getPullRequestUrl()).isEqualTo(new PullRequestUrl(pullRequestUrl)),
+                    () -> assertThat(runnerPost.getDeadline()).isEqualTo(new Deadline(deadline)),
+                    () -> assertThat(runnerPost.getRunnerPostTags()).isNotNull(),
+                    () -> assertThat(runnerPost.getChattingRoomCount()).isEqualTo(new ChattingRoomCount(0)),
+                    () -> assertThat(runnerPost.getWatchedCount()).isEqualTo(new WatchedCount(0))
+            );
         }
     }
 }

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/controller/RunnerPostControllerCreateTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/controller/RunnerPostControllerCreateTest.java
@@ -1,0 +1,87 @@
+package touch.baton.domain.runnerpost.controller;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import touch.baton.domain.common.vo.Grade;
+import touch.baton.domain.common.vo.TotalRating;
+import touch.baton.domain.member.Member;
+import touch.baton.domain.member.repository.MemberRepository;
+import touch.baton.domain.member.vo.Company;
+import touch.baton.domain.member.vo.Email;
+import touch.baton.domain.member.vo.GithubUrl;
+import touch.baton.domain.member.vo.MemberName;
+import touch.baton.domain.member.vo.OauthId;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.repository.RunnerRepository;
+import touch.baton.domain.runnerpost.service.dto.RunnerPostCreateRequest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+class RunnerPostControllerCreateTest {
+
+    @Autowired
+    private RunnerRepository runnerRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp(@LocalServerPort int port) {
+        RestAssured.port = port;
+
+        final Member member = Member.builder()
+                .memberName(new MemberName("헤에디주"))
+                .email(new Email("test@test.co.kr"))
+                .oauthId(new OauthId("dsigjh98gh230gn2oinv913bcuo23nqovbvu93b12voi3bc31j"))
+                .githubUrl(new GithubUrl("github.com/hyena0608"))
+                .company(new Company("우아한형제들")).build();
+        memberRepository.save(member);
+        final Runner runner = Runner.builder()
+                .totalRating(new TotalRating(100))
+                .grade(Grade.BARE_FOOT)
+                .member(member)
+                .build();
+        runnerRepository.save(runner);
+    }
+
+    @Test
+    void 러너_게시글_등록에_성공한다() {
+        // given
+        final RunnerPostCreateRequest request = new RunnerPostCreateRequest("코드 리뷰 해주세요.",
+                List.of("Java", "Spring"),
+                "https://github.com/cookienc",
+                LocalDateTime.of(2099, 12, 12, 0, 0),
+                "싸게 부탁드려요."
+        );
+
+        // when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(request)
+                .when()
+                .post("/api/v1/posts/runner")
+                .then()
+                .log().all().extract();
+
+        // then
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                () -> assertThat(response.header(HttpHeaders.LOCATION)).contains("/api/v1/posts/runner")
+        );
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerFixture.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerFixture.java
@@ -1,0 +1,50 @@
+package touch.baton.domain.runnerpost.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import touch.baton.config.JpaConfig;
+import touch.baton.domain.common.vo.Grade;
+import touch.baton.domain.common.vo.TotalRating;
+import touch.baton.domain.member.Member;
+import touch.baton.domain.member.repository.MemberRepository;
+import touch.baton.domain.member.vo.Company;
+import touch.baton.domain.member.vo.Email;
+import touch.baton.domain.member.vo.GithubUrl;
+import touch.baton.domain.member.vo.MemberName;
+import touch.baton.domain.member.vo.OauthId;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.repository.RunnerRepository;
+
+@Import(JpaConfig.class)
+@DataJpaTest
+public abstract class RunnerFixture {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RunnerRepository runnerRepository;
+
+    protected Member member;
+    protected Runner runner;
+
+    @BeforeEach
+    void setUpFixture() {
+        member = Member.builder()
+                .memberName(new MemberName("헤에디주"))
+                .email(new Email("test@test.co.kr"))
+                .oauthId(new OauthId("dsigjh98gh230gn2oinv913bcuo23nqovbvu93b12voi3bc31j"))
+                .githubUrl(new GithubUrl("github.com/hyena0608"))
+                .company(new Company("우아한형제들")).build();
+        runner = Runner.builder()
+                .totalRating(new TotalRating(100))
+                .grade(Grade.BARE_FOOT)
+                .member(member)
+                .build();
+
+        memberRepository.save(member);
+        runnerRepository.save(runner);
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceCreateTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceCreateTest.java
@@ -1,0 +1,72 @@
+package touch.baton.domain.runnerpost.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import touch.baton.domain.common.vo.ChattingRoomCount;
+import touch.baton.domain.common.vo.Contents;
+import touch.baton.domain.common.vo.Title;
+import touch.baton.domain.common.vo.WatchedCount;
+import touch.baton.domain.runnerpost.RunnerPost;
+import touch.baton.domain.runnerpost.repository.RunnerPostRepository;
+import touch.baton.domain.runnerpost.service.dto.RunnerPostCreateRequest;
+import touch.baton.domain.runnerpost.vo.Deadline;
+import touch.baton.domain.runnerpost.vo.PullRequestUrl;
+import touch.baton.domain.tag.repository.TagRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class RunnerPostServiceCreateTest extends RunnerFixture {
+
+    private static final String TITLE = "코드 리뷰 해주세요.";
+    private static final String TAG = "Java";
+    private static final String OTHER_TAG = "Spring";
+    private static final String PULL_REQUEST_URL = "https://github.com/cookienc";
+    private static final LocalDateTime DEADLINE = LocalDateTime.of(2099, 12, 12, 0, 0);
+    private static final String CONTENTS = "싸게 부탁드려요.";
+
+    private RunnerPostService runnerPostService;
+
+    @Autowired
+    private RunnerPostRepository runnerPostRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @BeforeEach
+    void setUp() {
+        runnerPostService = new RunnerPostService(runnerPostRepository, tagRepository);
+    }
+
+    @DisplayName("Runner post 저장에 성공한다.")
+    @Test
+    void success() {
+        // given
+        final RunnerPostCreateRequest request = new RunnerPostCreateRequest(TITLE,
+                List.of(TAG, OTHER_TAG),
+                PULL_REQUEST_URL,
+                DEADLINE,
+                CONTENTS);
+
+        // when
+        final Long savedId = runnerPostService.create(runner, request);
+
+        // then
+        assertThat(savedId).isNotNull();
+        RunnerPost actual = runnerPostRepository.findById(savedId).get();
+        assertAll(
+                () -> assertThat(actual.getTitle()).isEqualTo(new Title(TITLE)),
+                () -> assertThat(actual.getContents()).isEqualTo(new Contents(CONTENTS)),
+                () -> assertThat(actual.getPullRequestUrl()).isEqualTo(new PullRequestUrl(PULL_REQUEST_URL)),
+                () -> assertThat(actual.getDeadline()).isEqualTo(new Deadline(DEADLINE)),
+                () -> assertThat(actual.getWatchedCount()).isEqualTo(new WatchedCount(0)),
+                () -> assertThat(actual.getChattingRoomCount()).isEqualTo(new ChattingRoomCount(0)),
+                () -> assertThat(actual.getRunner()).isEqualTo(runner)
+        );
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/domain/tag/RunnerPostTagsTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/tag/RunnerPostTagsTest.java
@@ -1,0 +1,23 @@
+package touch.baton.domain.tag;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RunnerPostTagsTest {
+
+    @DisplayName("RunnerPostTags 에 runnerPostTag 를 추가할 수 있다.")
+    @Test
+    void addRunnerPostTags() {
+        // given
+//        RunnerPostTags postTags = new RunnerPostTags();
+//        RunnerPostTag.builder()
+//                .runnerPost()
+//                .tag(Tag.newInstance("Java"))
+//                .build()
+//
+//        // when
+//        postTags.add();
+        
+        // then
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/domain/tag/RunnerPostTagsTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/tag/RunnerPostTagsTest.java
@@ -2,22 +2,52 @@ package touch.baton.domain.tag;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import touch.baton.domain.common.vo.Grade;
+import touch.baton.domain.common.vo.TotalRating;
+import touch.baton.domain.member.Member;
+import touch.baton.domain.member.vo.Company;
+import touch.baton.domain.member.vo.Email;
+import touch.baton.domain.member.vo.GithubUrl;
+import touch.baton.domain.member.vo.MemberName;
+import touch.baton.domain.member.vo.OauthId;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runnerpost.RunnerPost;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class RunnerPostTagsTest {
 
     @DisplayName("RunnerPostTags 에 runnerPostTag 를 추가할 수 있다.")
     @Test
-    void addRunnerPostTags() {
+    void addAllRunnerPostTags() {
         // given
-//        RunnerPostTags postTags = new RunnerPostTags();
-//        RunnerPostTag.builder()
-//                .runnerPost()
-//                .tag(Tag.newInstance("Java"))
-//                .build()
-//
-//        // when
-//        postTags.add();
-        
+        RunnerPostTags postTags = new RunnerPostTags();
+        Member member = Member.builder()
+                .memberName(new MemberName("러너 사용자"))
+                .email(new Email("test@test.co.kr"))
+                .oauthId(new OauthId("ads7821iuqjkrhadsioh1f1r4efsoi3bc31j"))
+                .githubUrl(new GithubUrl("github.com/hyena0608"))
+                .company(new Company("우아한테크코스"))
+                .build();
+        Runner runner = Runner.builder()
+                .totalRating(new TotalRating(100))
+                .grade(Grade.BARE_FOOT)
+                .member(member)
+                .build();
+        final RunnerPost runnerpost = RunnerPost.newInstance("리뷰해주세요.", "제발요.", "https://github.com/cookienc", LocalDateTime.of(2099, 12, 12, 0, 0), runner);
+
+        final RunnerPostTag runnerPostTag = RunnerPostTag.builder()
+                .runnerPost(runnerpost)
+                .tag(Tag.newInstance("Java"))
+                .build();
+
+        // when
+        postTags.addAll(List.of(runnerPostTag));
+
         // then
+        assertThat(postTags.getRunnerPostTags()).hasSize(1);
     }
 }

--- a/backend/baton/src/test/java/touch/baton/domain/tag/TagTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/tag/TagTest.java
@@ -7,8 +7,10 @@ import touch.baton.domain.tag.exception.TagException;
 import touch.baton.domain.tag.vo.TagCount;
 import touch.baton.domain.tag.vo.TagName;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class TagTest {
 
@@ -45,5 +47,36 @@ class TagTest {
                     .build()
             ).isInstanceOf(TagException.NotNull.class);
         }
+    }
+
+    @DisplayName("기본 count 를 가진 tag 를 생성할 수 있다.")
+    @Test
+    void createDefaultTag() {
+        // given
+        final String tagName = "Java";
+        final Tag tag = Tag.newInstance(tagName);
+
+        // when, then
+        assertAll(
+                () -> assertThat(tag.getTagName()).isEqualTo(new TagName(tagName)),
+                () -> assertThat(tag.getTagCount()).isEqualTo(new TagCount(1))
+        );
+    }
+
+    @DisplayName("Tag 의 count는 1개씩 증가한다.")
+    @Test
+    void increaseCount() {
+        // given
+        final Tag tag = Tag.newInstance("Java");
+
+        // when
+        tag.increaseCount();
+
+        // then
+        assertAll(
+                () -> assertThat(tag.getTagName()).isEqualTo(new TagName("Java")),
+                () -> assertThat(tag.getTagCount()).isEqualTo(new TagCount(2))
+        );
+
     }
 }

--- a/backend/baton/src/test/java/touch/baton/domain/tag/repository/TagRepositoryTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/tag/repository/TagRepositoryTest.java
@@ -1,0 +1,41 @@
+package touch.baton.domain.tag.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import touch.baton.config.JpaConfig;
+import touch.baton.domain.tag.Tag;
+import touch.baton.domain.tag.vo.TagCount;
+import touch.baton.domain.tag.vo.TagName;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(JpaConfig.class)
+@DataJpaTest
+class TagRepositoryTest {
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @DisplayName("이름으로 단건 검색한다.")
+    @Test
+    void findByName() {
+        // given
+        final String newTagName = "Java";
+        final Tag newTag = Tag.builder()
+                .tagName(new TagName(newTagName))
+                .tagCount(new TagCount(0))
+                .build();
+        final Tag expected = tagRepository.save(newTag);
+
+        // when
+        final Optional<Tag> actual = tagRepository.findByTagName(new TagName(newTagName));
+
+        // then
+        assertThat(actual).contains(expected);
+    }
+}


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #21 

## 참고사항
- 현재 로그인이 구현되어 있지 않아, 직접 1L의 러너를 찾아오도록 로직을 짜놨습니다. 나중에 수정해야 합니다.