### PR TITLE
API 문서 자동화를 위한 Restdocs 설정

### DIFF
--- a/backend/baton/build.gradle
+++ b/backend/baton/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java'
+	id 'java-test-fixtures'
 	id 'org.springframework.boot' version '3.1.1'
 	id 'io.spring.dependency-management' version '1.1.0'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
@@ -10,6 +11,10 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	sourceCompatibility = '17'
+}
+
+configurations {
+	asciidoctorExt
 }
 
 configurations {
@@ -44,6 +49,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.testcontainers:mysql'
+
+	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 tasks.named('test') {
@@ -53,5 +60,6 @@ tasks.named('test') {
 
 tasks.named('asciidoctor') {
 	inputs.dir snippetsDir
+	configurations 'asciidoctorExt'
 	dependsOn test
 }

--- a/backend/baton/src/test/java/touch/baton/config/AssuredTestConfig.java
+++ b/backend/baton/src/test/java/touch/baton/config/AssuredTestConfig.java
@@ -15,9 +15,6 @@ import touch.baton.domain.runnerpost.repository.RunnerPostRepository;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public abstract class AssuredTestConfig {
 
-    @LocalServerPort
-    private int port;
-
     @Autowired
     protected MemberRepository memberRepository;
 
@@ -28,7 +25,7 @@ public abstract class AssuredTestConfig {
     protected RunnerPostRepository runnerPostRepository;
 
     @BeforeEach
-    void assuredTestSetUp() {
+    void assuredTestSetUp(@LocalServerPort int port) {
         RestAssured.port = port;
     }
 }

--- a/backend/baton/src/test/java/touch/baton/config/RestdocsConfig.java
+++ b/backend/baton/src/test/java/touch/baton/config/RestdocsConfig.java
@@ -1,0 +1,57 @@
+package touch.baton.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+@ExtendWith(MockitoExtension.class)
+@Import(RestDocsResultConfig.class)
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestdocsConfig {
+
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected RestDocumentationResultHandler restDocs;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @BeforeEach
+    void restdocsSetUp(final WebApplicationContext webApplicationContext,
+                       final RestDocumentationContextProvider restDocumentation
+    ) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation))
+                .build();
+    }
+}
+
+@TestConfiguration
+class RestDocsResultConfig {
+
+    @Bean
+    RestDocumentationResultHandler restDocumentationResultHandler() {
+        return MockMvcRestDocumentation.document("{class-name}/{method-name}",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint())
+        );
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/document/runnerpost/read/RunnerPostReadApiTest.java
+++ b/backend/baton/src/test/java/touch/baton/document/runnerpost/read/RunnerPostReadApiTest.java
@@ -1,0 +1,79 @@
+package touch.baton.document.runnerpost.read;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import touch.baton.config.RestdocsConfig;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.service.RunnerService;
+import touch.baton.domain.runnerpost.RunnerPost;
+import touch.baton.domain.runnerpost.controller.RunnerPostController;
+import touch.baton.domain.runnerpost.service.RunnerPostService;
+import touch.baton.domain.runnerpost.vo.Deadline;
+import touch.baton.domain.tag.Tag;
+import touch.baton.fixture.domain.MemberFixture;
+import touch.baton.fixture.domain.RunnerFixture;
+import touch.baton.fixture.domain.RunnerPostFixture;
+import touch.baton.fixture.domain.TagFixture;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.spy;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static touch.baton.fixture.vo.DeadlineFixture.deadline;
+import static touch.baton.fixture.vo.TagCountFixture.tagCount;
+import static touch.baton.fixture.vo.TagNameFixture.tagName;
+
+@WebMvcTest(RunnerPostController.class)
+class RunnerPostReadApiTest extends RestdocsConfig {
+
+    @MockBean
+    private RunnerPostService runnerPostService;
+
+    @MockBean
+    private RunnerService runnerService;
+
+    @DisplayName("러너 게시글 전체 조회 API")
+    @Test
+    void readAllRunnerPosts() throws Exception {
+        // given
+        final Runner runner = RunnerFixture.createRunner(MemberFixture.createHyena());
+        final Deadline deadline = deadline(LocalDateTime.now().plusHours(100));
+        final Tag javaTag = TagFixture.create(tagName("자바"), tagCount(10));
+        final RunnerPost runnerPost = RunnerPostFixture.create(runner, deadline, List.of(javaTag));
+        final RunnerPost spyRunnerPost = spy(runnerPost);
+
+        // when
+        given(spyRunnerPost.getId()).willReturn(1L);
+        given(runnerPostService.readAllRunnerPosts()).willReturn(List.of(spyRunnerPost));
+
+        // then
+        mockMvc.perform(get("/api/v1/posts/runner"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(APPLICATION_JSON))
+                .andDo(restDocs.document(
+                        responseFields(
+                                fieldWithPath("data.[].runnerPostId").type(NUMBER).description("러너 게시글 식별자값(id)"),
+                                fieldWithPath("data.[].title").type(STRING).description("러너 게시글의 제목"),
+                                fieldWithPath("data.[].deadline").type(STRING).description("러너 게시글의 마감 기한"),
+                                fieldWithPath("data.[].watchedCount").type(NUMBER).description("러너 게시글의 조회수"),
+                                fieldWithPath("data.[].chattingCount").type(NUMBER).description("러너 게시글의 채팅수"),
+                                fieldWithPath("data.[].reviewStatus").type(STRING).description("러너 게시글의 리뷰 상태"),
+                                fieldWithPath("data.[].runnerProfile.name").type(STRING).description("러너 게시글의 러너 프로필 이름"),
+                                fieldWithPath("data.[].runnerProfile.imageUrl").type(STRING).description("러너 게시글의 러너 프로필 이미지"),
+                                fieldWithPath("data.[].tags.[]").type(ARRAY).description("러너 게시글의 태그 목록")
+                        ))
+                );
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/fixture/domain/RunnerPostFixture.java
+++ b/backend/baton/src/test/java/touch/baton/fixture/domain/RunnerPostFixture.java
@@ -10,9 +10,13 @@ import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.PullRequestUrl;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
 import touch.baton.domain.supporter.Supporter;
+import touch.baton.domain.tag.RunnerPostTag;
+import touch.baton.domain.tag.RunnerPostTagFixture;
 import touch.baton.domain.tag.RunnerPostTags;
+import touch.baton.domain.tag.Tag;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public abstract class RunnerPostFixture {
 
@@ -58,6 +62,30 @@ public abstract class RunnerPostFixture {
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
                 .build();
     }
+
+    public static RunnerPost create(final Runner runner, final Deadline deadline, List<Tag> tags) {
+        final RunnerPost runnerPost = RunnerPost.builder()
+                .title(new Title("테스트 제목"))
+                .contents(new Contents("테스트 내용"))
+                .pullRequestUrl(new PullRequestUrl("https://테스트"))
+                .deadline(deadline)
+                .watchedCount(new WatchedCount(0))
+                .chattingCount(new ChattingCount(0))
+                .reviewStatus(ReviewStatus.NOT_STARTED)
+                .runner(runner)
+                .supporter(null)
+                .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
+                .build();
+
+        final List<RunnerPostTag> runnerPostTags = tags.stream()
+                .map(tag -> RunnerPostTagFixture.create(runnerPost, tag))
+                .toList();
+
+        runnerPost.addAllRunnerPostTags(runnerPostTags);
+
+        return runnerPost;
+    }
+
 
     public static RunnerPost create(final Runner runner, final RunnerPostTags runnerPostTags, final Deadline deadline) {
         return RunnerPost.builder()


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #126

## 참고사항
- RestdocsConfig를 상속받아 테스트를 진행한다.
- Restdocs 관련 Controller 테스트 패키지는 test/java/touch/baton/document 에 둔다.
- MockMvc 코드 컨벤션은 노션에 기록되어 있다.