### PR TITLE
CORS 환경별로 allowed origin 변경

### DIFF
--- a/backend/baton/.gitignore
+++ b/backend/baton/.gitignore
@@ -178,6 +178,5 @@ gradle-app.setting
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,java,gradle,intellij+all
 
-src/main/resources/application.yml
 src/main/resources/application-deploy.yml
 src/main/resources/application-dev.yml

--- a/backend/baton/.gitignore
+++ b/backend/baton/.gitignore
@@ -178,5 +178,6 @@ gradle-app.setting
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,java,gradle,intellij+all
 
-src/main/resources/application-prod.yml
+src/main/resources/application.yml
+src/main/resources/application-deploy.yml
 src/main/resources/application-dev.yml

--- a/backend/baton/src/main/java/touch/baton/config/WebMvcConfig.java
+++ b/backend/baton/src/main/java/touch/baton/config/WebMvcConfig.java
@@ -1,22 +1,23 @@
 package touch.baton.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
 import static org.springframework.http.HttpHeaders.LOCATION;
-import static org.springframework.http.HttpMethod.DELETE;
-import static org.springframework.http.HttpMethod.GET;
-import static org.springframework.http.HttpMethod.OPTIONS;
-import static org.springframework.http.HttpMethod.PATCH;
-import static org.springframework.http.HttpMethod.POST;
-import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpMethod.*;
 
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Value("${cors.allowed-origin}")
+    private String allowedOrigin;
+
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000")
+                .allowedOrigins(allowedOrigin)
                 .allowCredentials(false)
                 .allowedMethods(GET.name(), POST.name(), PUT.name(), PATCH.name(), DELETE.name(), OPTIONS.name())
                 .exposedHeaders(LOCATION)

--- a/backend/baton/src/main/resources/application.yml
+++ b/backend/baton/src/main/resources/application.yml
@@ -11,3 +11,13 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.orm.jdbc.bind: trace
+
+oauth:
+  github:
+    client_id: ${GITHUB_CLIENT_ID}
+    redirect_uri: ${GITHUB_REDIRECT_URI}
+    client_secret: ${GITHUB_CLIENT_SECRET}
+    scope: ${GITHUB_SCOPE}
+
+cors:
+  allowed-origin: http://localhost:8080


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #165 

## 참고사항
노션에 적어두었는데, application.yml에 github 소셜 로그인 관련 환경변수를 intellij 자체 환경변수로 되게끔 변경했어요.
개인별로 intellij에 환경변수 이름에 맞게 등록해주셔야 할 것 같아요.

gitignore로 application.yml 가리지 않은 이유는, 이미 한 번 레포에 올라간 application.yml은 gitignore로 숨겨봤자 숨겨지지 않더라구요. 업데이트되면 업데이트 된 상태로 staged 되어 차라리 intellij 환경 변수로 가렸습니다.
