### PR TITLE
Auth ArgumentResolver 익명 null 반환 변경

### DIFF
--- a/backend/baton/src/main/java/touch/baton/domain/oauth/controller/resolver/AuthRunnerPrincipal.java
+++ b/backend/baton/src/main/java/touch/baton/domain/oauth/controller/resolver/AuthRunnerPrincipal.java
@@ -9,5 +9,4 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AuthRunnerPrincipal {
 
-    boolean required() default true;
 }

--- a/backend/baton/src/main/java/touch/baton/domain/oauth/controller/resolver/AuthSupporterPrincipal.java
+++ b/backend/baton/src/main/java/touch/baton/domain/oauth/controller/resolver/AuthSupporterPrincipal.java
@@ -9,5 +9,4 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AuthSupporterPrincipal {
 
-    boolean required() default true;
 }

--- a/backend/baton/src/main/java/touch/baton/domain/oauth/controller/resolver/AuthSupporterPrincipalArgumentResolver.java
+++ b/backend/baton/src/main/java/touch/baton/domain/oauth/controller/resolver/AuthSupporterPrincipalArgumentResolver.java
@@ -9,6 +9,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import touch.baton.domain.common.exception.ClientErrorCode;
+import touch.baton.domain.common.vo.Introduction;
 import touch.baton.domain.oauth.exception.OauthRequestException;
 import touch.baton.domain.oauth.repository.OauthSupporterRepository;
 import touch.baton.domain.supporter.Supporter;
@@ -39,13 +40,12 @@ public class AuthSupporterPrincipalArgumentResolver implements HandlerMethodArgu
                                   final WebDataBinderFactory binderFactory
     ) throws Exception {
         final String authHeader = webRequest.getHeader(AUTHORIZATION);
-        // FIXME: 2023/08/03 null 말고 GUEST, USER, ADMIN role 추가해야할 것 같아요.
-        if (!Objects.requireNonNull(parameter.getParameterAnnotation(AuthRunnerPrincipal.class)).required()) {
-            return getSupporterIfExist(authHeader);
-        }
-
         if (Objects.isNull(authHeader)) {
-            throw new OauthRequestException(ClientErrorCode.OAUTH_AUTHORIZATION_VALUE_IS_NULL);
+            return Supporter.builder()
+                    .introduction(new Introduction(""))
+                    .supporterTechnicalTags(null)
+                    .member(null)
+                    .build();
         }
         if (!authHeader.startsWith(BEARER)) {
             throw new OauthRequestException(ClientErrorCode.OAUTH_AUTHORIZATION_BEARER_TYPE_NOT_FOUND);
@@ -54,26 +54,7 @@ public class AuthSupporterPrincipalArgumentResolver implements HandlerMethodArgu
         final String token = authHeader.substring(BEARER.length());
         final Claims claims = jwtDecoder.parseJwtToken(token);
         final String socialId = claims.get("socialId", String.class);
-        final Supporter foundSupporter = oauthSupporterRepository.joinByMemberSocialId(socialId)
+        return oauthSupporterRepository.joinByMemberSocialId(socialId)
                 .orElseThrow(() -> new OauthRequestException(ClientErrorCode.JWT_CLAIM_SOCIAL_ID_IS_WRONG));
-
-        return foundSupporter;
-    }
-
-    private Supporter getSupporterIfExist(final String authHeader) {
-        if (Objects.isNull(authHeader)) {
-            return null;
-        }
-        if (!authHeader.startsWith(BEARER)) {
-            throw new OauthRequestException(ClientErrorCode.OAUTH_AUTHORIZATION_BEARER_TYPE_NOT_FOUND);
-        }
-
-        final String token = authHeader.substring(BEARER.length());
-        final Claims claims = jwtDecoder.parseJwtToken(token);
-        final String socialId = claims.get("socialId", String.class);
-        final Supporter foundSupporter = oauthSupporterRepository.joinByMemberSocialId(socialId)
-                .orElseThrow(() -> new OauthRequestException(ClientErrorCode.JWT_CLAIM_SOCIAL_ID_IS_WRONG));
-
-        return foundSupporter;
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/RunnerPostController.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/RunnerPostController.java
@@ -57,7 +57,7 @@ public class RunnerPostController {
     }
 
     @GetMapping("/{runnerPostId}")
-    public ResponseEntity<RunnerPostResponse.Detail> readByRunnerPostId(@AuthRunnerPrincipal(required = false) final Runner runner,
+    public ResponseEntity<RunnerPostResponse.Detail> readByRunnerPostId(@AuthRunnerPrincipal final Runner runner,
                                                                         @PathVariable final Long runnerPostId
     ) {
         final RunnerPost runnerPost = runnerPostService.readByRunnerPostId(runnerPostId);
@@ -72,7 +72,7 @@ public class RunnerPostController {
     }
 
     @GetMapping("/{runnerPostId}/test")
-    public ResponseEntity<RunnerPostResponse.DetailVersionTest> readByRunnerPostIdVersionTest(@AuthRunnerPrincipal(required = false) final Runner runner,
+    public ResponseEntity<RunnerPostResponse.DetailVersionTest> readByRunnerPostIdVersionTest(@AuthRunnerPrincipal final Runner runner,
                                                                                               @PathVariable final Long runnerPostId
     ) {
         final RunnerPost runnerPost = runnerPostService.readByRunnerPostId(runnerPostId);


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #270

## 참고사항
- ArgumentResolver 내부 로직 변경
- @AuthRunnerPrincipal, @AuthSupporterPrincipal 내부 속성 삭제
- 이후 Runner, Supporter를 익명으로 진행할 경우 null 처리를 진행해야 한다.
(* null 처리가 중복적으로 진행되어야 하여 프로덕션 코드에 영향이 클 때 다른 기술을 도입하여 해결해야 한다.)