### PR TITLE
러너 본인 프로필 조회 API 구현

### DIFF
--- a/backend/baton/src/docs/asciidoc/RunnerProfileReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerProfileReadApi.adoc
@@ -10,9 +10,9 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-== *로그인된 사용자 프로필 조회*
+== *러너 본인 프로필 조회*
 
-=== *로그인된 사용자 프로필 조회 조회 API*
+=== *러너 본인 프로필 조회 API*
 
 ==== *Http Request*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/http-request.adoc[]

--- a/backend/baton/src/docs/asciidoc/RunnerProfileReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerProfileReadApi.adoc
@@ -1,0 +1,27 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+:doctype: investment
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 2
+:sectlinks:
+:operation-http-request-title: Example Request
+:operation-http-response-title: Example Response
+
+== *로그인된 사용자 프로필 조회*
+
+=== *로그인된 사용자 프로필 조회 조회 API*
+
+==== *Http Request*
+include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/http-request.adoc[]
+
+==== *Http Request Headers*
+include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/request-headers.adoc[]
+
+==== *Http Response*
+include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/http-response.adoc[]
+
+==== *Http Response Fields*
+include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/response-fields.adoc[]

--- a/backend/baton/src/main/java/touch/baton/domain/runner/Runner.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runner/Runner.java
@@ -14,6 +14,7 @@ import touch.baton.domain.common.BaseEntity;
 import touch.baton.domain.common.vo.Introduction;
 import touch.baton.domain.member.Member;
 import touch.baton.domain.runner.exception.RunnerDomainException;
+import touch.baton.domain.technicaltag.RunnerTechnicalTags;
 
 import java.util.Objects;
 
@@ -37,26 +38,35 @@ public class Runner extends BaseEntity {
     @JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "fk_runner_to_member"), nullable = false)
     private Member member;
 
+    @Embedded
+    private RunnerTechnicalTags runnerTechnicalTags;
+
     @Builder
-    private Runner( final Introduction introduction,
-                   final Member member
+    private Runner(final Introduction introduction,
+                   final Member member,
+                   final RunnerTechnicalTags runnerTechnicalTags
     ) {
-        this(null, introduction, member);
+        this(null, introduction, member, runnerTechnicalTags);
     }
 
     private Runner(final Long id,
                    final Introduction introduction,
-                   final Member member
+                   final Member member,
+                   final RunnerTechnicalTags runnerTechnicalTags
     ) {
-        validateNotNull(member);
+        validateNotNull(member, runnerTechnicalTags);
         this.id = id;
         this.introduction = introduction;
         this.member = member;
+        this.runnerTechnicalTags = runnerTechnicalTags;
     }
 
-    private void validateNotNull(final Member member) {
+    private void validateNotNull(final Member member, final RunnerTechnicalTags runnerTechnicalTags) {
         if (Objects.isNull(member)) {
             throw new RunnerDomainException("Runner 의 member 는 null 일 수 없습니다.");
+        }
+        if (Objects.isNull(runnerTechnicalTags)) {
+            throw new RunnerDomainException("Runner 의 runnerTechnicalTags 는 null 일 수 없습니다.");
         }
     }
 

--- a/backend/baton/src/main/java/touch/baton/domain/runner/controller/RunnerProfileController.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runner/controller/RunnerProfileController.java
@@ -29,4 +29,11 @@ public class RunnerProfileController {
                 .toList();
         return ResponseEntity.ok(new RunnerMyProfileResponse(me, runnerPosts));
     }
+
+    @GetMapping("/me")
+    public ResponseEntity<RunnerResponse.MyProfile> readMyProfileByToken(@AuthRunnerPrincipal Runner runner) {
+        final RunnerResponse.MyProfile response = RunnerResponse.MyProfile.from(runner);
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runner/controller/response/RunnerResponse.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runner/controller/response/RunnerResponse.java
@@ -2,6 +2,8 @@ package touch.baton.domain.runner.controller.response;
 
 import touch.baton.domain.runner.Runner;
 
+import java.util.List;
+
 public record RunnerResponse() {
 
     public record Detail(Long runnerId,
@@ -43,6 +45,32 @@ public record RunnerResponse() {
                     runner.getMember().getGithubUrl().getValue(),
                     runner.getIntroduction().getValue()
             );
+        }
+    }
+
+    public record MyProfile(String name,
+                            String company,
+                            String imageUrl,
+                            String githubUrl,
+                            String introduction,
+                            List<String> technicalTags
+    ) {
+
+        public static MyProfile from(final Runner runner) {
+            return new MyProfile(
+                    runner.getMember().getMemberName().getValue(),
+                    runner.getMember().getCompany().getValue(),
+                    runner.getMember().getImageUrl().getValue(),
+                    runner.getMember().getGithubUrl().getValue(),
+                    runner.getIntroduction().getValue(),
+                    convertRunnerTechnicalTags(runner)
+            );
+        }
+
+        private static List<String> convertRunnerTechnicalTags(final Runner runner) {
+            return runner.getRunnerTechnicalTags().getRunnerTechnicalTags().stream()
+                    .map(runnerTechnicalTag -> runnerTechnicalTag.getTechnicalTag().getTagName().getValue())
+                    .toList();
         }
     }
 }

--- a/backend/baton/src/test/java/touch/baton/assure/runner/RunnerProfileAssuredReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/assure/runner/RunnerProfileAssuredReadTest.java
@@ -1,0 +1,30 @@
+package touch.baton.assure.runner;
+
+import org.junit.jupiter.api.Test;
+import touch.baton.config.AssuredTestConfig;
+import touch.baton.domain.member.Member;
+import touch.baton.domain.runner.Runner;
+import touch.baton.fixture.domain.MemberFixture;
+import touch.baton.fixture.domain.RunnerFixture;
+
+import static touch.baton.assure.runner.RunnerProfileAssuredSupport.러너_본인_프로필_응답;
+import static touch.baton.fixture.vo.IntroductionFixture.introduction;
+
+@SuppressWarnings("NonAsciiCharacters")
+class RunnerProfileAssuredReadTest extends AssuredTestConfig {
+
+    @Test
+    void 러너_본인_프로필을_가지고_있는_토큰으로_조회에_성공한다() {
+        final Member 사용자_헤나 = memberRepository.save(MemberFixture.createHyena());
+        final Runner 러너_헤나 = runnerRepository.save(RunnerFixture.create(introduction("안녕하세요"), 사용자_헤나));
+        final String 로그인용_토큰 = login(사용자_헤나.getSocialId().getValue());
+
+        RunnerProfileAssuredSupport
+                .클라이언트_요청()
+                .토큰으로_로그인한다(로그인용_토큰)
+                .러너_본인_프로필을_가지고_있는_토큰으로_조회한다()
+
+                .서버_응답()
+                .러너_본인_프로필_조회_성공을_검증한다(러너_본인_프로필_응답(러너_헤나));
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/assure/runner/RunnerProfileAssuredSupport.java
+++ b/backend/baton/src/test/java/touch/baton/assure/runner/RunnerProfileAssuredSupport.java
@@ -1,0 +1,67 @@
+package touch.baton.assure.runner;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import touch.baton.assure.common.AssuredSupport;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.controller.response.RunnerResponse;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+public class RunnerProfileAssuredSupport {
+
+    private RunnerProfileAssuredSupport() {
+    }
+
+    public static RunnerClientRequestBuilder 클라이언트_요청() {
+        return new RunnerClientRequestBuilder();
+    }
+
+    public static RunnerResponse.MyProfile 러너_본인_프로필_응답(final Runner 러너) {
+        return RunnerResponse.MyProfile.from(러너);
+    }
+
+    public static class RunnerClientRequestBuilder {
+
+        private ExtractableResponse<Response> response;
+
+        private String accessToken;
+
+        public RunnerClientRequestBuilder 토큰으로_로그인한다(final String 토큰) {
+            this.accessToken = 토큰;
+            return this;
+        }
+
+        public RunnerClientRequestBuilder 러너_본인_프로필을_가지고_있는_토큰으로_조회한다() {
+            response = AssuredSupport.get("/api/v1/profile/runner/me", accessToken);
+            return this;
+        }
+
+        public RunnerServerResponseBuilder 서버_응답() {
+            return new RunnerServerResponseBuilder(response);
+        }
+    }
+
+    public static class RunnerServerResponseBuilder {
+
+        private final ExtractableResponse<Response> response;
+
+        public RunnerServerResponseBuilder(final ExtractableResponse<Response> response) {
+            this.response = response;
+        }
+
+        public void 러너_본인_프로필_조회_성공을_검증한다(final RunnerResponse.MyProfile 러너_본인_프로필_응답) {
+            final RunnerResponse.MyProfile actual = this.response.as(RunnerResponse.MyProfile.class);
+
+            assertSoftly(softly -> {
+                        softly.assertThat(actual.name()).isEqualTo(러너_본인_프로필_응답.name());
+                        softly.assertThat(actual.company()).isEqualTo(러너_본인_프로필_응답.company());
+                        softly.assertThat(actual.imageUrl()).isEqualTo(러너_본인_프로필_응답.imageUrl());
+                        softly.assertThat(actual.githubUrl()).isEqualTo(러너_본인_프로필_응답.githubUrl());
+                        softly.assertThat(actual.introduction()).isEqualTo(러너_본인_프로필_응답.introduction());
+                        softly.assertThat(actual.technicalTags()).isEqualTo(러너_본인_프로필_응답.technicalTags());
+                    }
+            );
+        }
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostAssuredReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostAssuredReadTest.java
@@ -13,7 +13,7 @@ import touch.baton.fixture.domain.RunnerFixture;
 import touch.baton.fixture.domain.RunnerPostFixture;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
+import java.util.ArrayList;
 
 import static touch.baton.fixture.vo.DeadlineFixture.deadline;
 import static touch.baton.fixture.vo.IntroductionFixture.introduction;
@@ -45,7 +45,7 @@ class RunnerPostAssuredReadTest extends AssuredTestConfig {
                         ReviewStatus.NOT_STARTED,
                         true,
                         RunnerResponse.Detail.from(러너_헤나),
-                        Collections.emptyList()
+                        new ArrayList<>()
                 ));
     }
 }

--- a/backend/baton/src/test/java/touch/baton/config/AssuredTestConfig.java
+++ b/backend/baton/src/test/java/touch/baton/config/AssuredTestConfig.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestExecutionListeners;
 import touch.baton.domain.member.repository.MemberRepository;
 import touch.baton.domain.runner.repository.RunnerRepository;
 import touch.baton.domain.runnerpost.repository.RunnerPostRepository;
@@ -20,6 +22,8 @@ import java.util.UUID;
 
 import static org.mockito.BDDMockito.when;
 
+@Import(JpaConfig.class)
+@TestExecutionListeners(value = AssuredTestExecutionListener.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public abstract class AssuredTestConfig {
@@ -42,6 +46,11 @@ public abstract class AssuredTestConfig {
     @BeforeEach
     void assuredTestSetUp(@LocalServerPort int port) {
         RestAssured.port = port;
+
+        memberRepository.deleteAll();
+        runnerRepository.deleteAll();
+        runnerPostRepository.deleteAll();
+        supporterRepository.deleteAll();
     }
 
     public String login(final String socialId) {

--- a/backend/baton/src/test/java/touch/baton/config/AssuredTestConfig.java
+++ b/backend/baton/src/test/java/touch/baton/config/AssuredTestConfig.java
@@ -46,11 +46,6 @@ public abstract class AssuredTestConfig {
     @BeforeEach
     void assuredTestSetUp(@LocalServerPort int port) {
         RestAssured.port = port;
-
-        memberRepository.deleteAll();
-        runnerRepository.deleteAll();
-        runnerPostRepository.deleteAll();
-        supporterRepository.deleteAll();
     }
 
     public String login(final String socialId) {

--- a/backend/baton/src/test/java/touch/baton/config/AssuredTestExecutionListener.java
+++ b/backend/baton/src/test/java/touch/baton/config/AssuredTestExecutionListener.java
@@ -1,0 +1,39 @@
+package touch.baton.config;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+import java.util.List;
+
+public class AssuredTestExecutionListener extends AbstractTestExecutionListener {
+
+    @Override
+    public void afterTestMethod(final TestContext testContext) {
+        final JdbcTemplate jdbcTemplate = getJdbcTemplate(testContext);
+        final List<String> truncateQueries = getTruncateQueries(jdbcTemplate);
+        truncateTables(jdbcTemplate, truncateQueries);
+    }
+
+    private List<String> getTruncateQueries(final JdbcTemplate jdbcTemplate) {
+        return jdbcTemplate.queryForList("""
+                SELECT Concat('TRUNCATE TABLE ', TABLE_NAME, ';') AS q 
+                FROM INFORMATION_SCHEMA.TABLES 
+                WHERE TABLE_SCHEMA = 'PUBLIC'
+                """, String.class);
+    }
+
+    private JdbcTemplate getJdbcTemplate(final TestContext testContext) {
+        return testContext.getApplicationContext().getBean(JdbcTemplate.class);
+    }
+
+    private void truncateTables(final JdbcTemplate jdbcTemplate, final List<String> truncateQueries) {
+        execute(jdbcTemplate, "SET REFERENTIAL_INTEGRITY FALSE");
+        truncateQueries.forEach(v -> execute(jdbcTemplate, v));
+        execute(jdbcTemplate, "SET REFERENTIAL_INTEGRITY TRUE");
+    }
+
+    private void execute(final JdbcTemplate jdbcTemplate, final String query) {
+        jdbcTemplate.execute(query);
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/document/profile/runner/read/RunnerProfileReadApiTest.java
+++ b/backend/baton/src/test/java/touch/baton/document/profile/runner/read/RunnerProfileReadApiTest.java
@@ -1,10 +1,78 @@
 package touch.baton.document.profile.runner.read;
 
-//@WebMvcTest(RunnerProfileController.class)
-//public class RunnerProfileReadApiTest extends RestdocsConfig {
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import touch.baton.config.RestdocsConfig;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.controller.RunnerProfileController;
+import touch.baton.domain.runnerpost.service.RunnerPostService;
+import touch.baton.domain.technicaltag.TechnicalTag;
+import touch.baton.fixture.domain.MemberFixture;
+import touch.baton.fixture.domain.RunnerFixture;
+import touch.baton.fixture.domain.TechnicalTagFixture;
 
-//    @MockBean
-//    private RunnerPostService runnerPostService;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.BDDMockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static touch.baton.fixture.vo.TagNameFixture.tagName;
+
+@WebMvcTest(RunnerProfileController.class)
+class RunnerProfileReadApiTest extends RestdocsConfig {
+
+    @MockBean
+    RunnerPostService runnerPostService;
+
+    @BeforeEach
+    void setUp() {
+        restdocsSetUp(new RunnerProfileController(runnerPostService));
+    }
+
+    @DisplayName("러너 본인 프로필 조회 API")
+    @Test
+    void readMyProfileByToken() throws Exception {
+        // given
+        final TechnicalTag java = TechnicalTagFixture.create(tagName("java"));
+        final TechnicalTag spring = TechnicalTagFixture.create(tagName("spring"));
+        final Runner runner = RunnerFixture.createRunner(MemberFixture.createHyena(), List.of(java, spring));
+        final String token = getAccessTokenBySocialId(runner.getMember().getSocialId().getValue());
+
+        when(oauthRunnerRepository.joinByMemberSocialId(notNull()))
+                .thenReturn(Optional.ofNullable(runner));
+
+        // then
+        mockMvc.perform(get("/api/v1/profile/runner/me")
+                        .header(AUTHORIZATION, "Bearer " + token))
+                .andDo(print())
+                .andDo(restDocs.document(
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION).description("Bearer JWT")
+                        ),
+                        responseFields(
+                                fieldWithPath("name").type(STRING).description("러너 이름"),
+                                fieldWithPath("company").type(STRING).description("러너 소속 회사"),
+                                fieldWithPath("imageUrl").type(STRING).description("러너 프로필 이미지 url"),
+                                fieldWithPath("githubUrl").type(STRING).description("러너 깃허브 url"),
+                                fieldWithPath("introduction").type(STRING).description("러너 자기소개"),
+                                fieldWithPath("technicalTags").type(ARRAY).description("러너 기술 태그 목록")
+                        )
+                ))
+                .andDo(print());
+    }
+
 
 //    @DisplayName("러너 프로필 조회 API")
 //    @Test
@@ -21,4 +89,4 @@ package touch.baton.document.profile.runner.read;
 //
 //        // then
 //    }
-//}
+}

--- a/backend/baton/src/test/java/touch/baton/domain/runner/RunnerTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runner/RunnerTest.java
@@ -3,6 +3,7 @@ package touch.baton.domain.runner;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import touch.baton.domain.common.vo.Introduction;
 import touch.baton.domain.member.Member;
 import touch.baton.domain.member.vo.Company;
 import touch.baton.domain.member.vo.GithubUrl;
@@ -11,6 +12,9 @@ import touch.baton.domain.member.vo.MemberName;
 import touch.baton.domain.member.vo.OauthId;
 import touch.baton.domain.member.vo.SocialId;
 import touch.baton.domain.runner.exception.RunnerDomainException;
+import touch.baton.domain.technicaltag.RunnerTechnicalTags;
+
+import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,7 +38,9 @@ class RunnerTest {
         @Test
         void success() {
             assertThatCode(() -> Runner.builder()
+                    .introduction(new Introduction("안녕하세요. 헤에디주입니다."))
                     .member(member)
+                    .runnerTechnicalTags(new RunnerTechnicalTags(new ArrayList<>()))
                     .build()
             ).doesNotThrowAnyException();
         }
@@ -43,10 +49,23 @@ class RunnerTest {
         @Test
         void fail_if_member_is_null() {
             assertThatThrownBy(() -> Runner.builder()
+                    .introduction(new Introduction("안녕하세요. 헤에디주입니다."))
                     .member(null)
+                    .runnerTechnicalTags(new RunnerTechnicalTags(new ArrayList<>()))
                     .build()
             ).isInstanceOf(RunnerDomainException.class)
                     .hasMessage("Runner 의 member 는 null 일 수 없습니다.");
+        }
+
+        @DisplayName("runnerTechnicalTags 가 null 이 들어갈 경우 예외가 발생한다.")
+        @Test
+        void fail_if_runnerTechnicalTags_is_null() {
+            assertThatThrownBy(() -> Runner.builder()
+                    .introduction(new Introduction("안녕하세요. 헤에디주입니다."))
+                    .member(member)
+                    .runnerTechnicalTags(null)
+                    .build()
+            ).isInstanceOf(RunnerDomainException.class);
         }
     }
 }

--- a/backend/baton/src/test/java/touch/baton/domain/runner/repository/RunnerRepositoryTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runner/repository/RunnerRepositoryTest.java
@@ -14,7 +14,9 @@ import touch.baton.domain.member.vo.MemberName;
 import touch.baton.domain.member.vo.OauthId;
 import touch.baton.domain.member.vo.SocialId;
 import touch.baton.domain.runner.Runner;
+import touch.baton.fixture.domain.RunnerTechnicalTagsFixture;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +53,7 @@ class RunnerRepositoryTest extends RepositoryTestConfig {
 
         runner = Runner.builder()
                 .member(member)
+                .runnerTechnicalTags(RunnerTechnicalTagsFixture.create(new ArrayList<>()))
                 .build();
     }
 

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/RunnerPostTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/RunnerPostTest.java
@@ -24,6 +24,7 @@ import touch.baton.domain.tag.RunnerPostTag;
 import touch.baton.domain.tag.RunnerPostTags;
 import touch.baton.domain.tag.Tag;
 import touch.baton.domain.technicaltag.SupporterTechnicalTags;
+import touch.baton.fixture.domain.RunnerTechnicalTagsFixture;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -54,6 +55,7 @@ class RunnerPostTest {
 
     private final Runner runner = Runner.builder()
             .member(runnerMember)
+            .runnerTechnicalTags(RunnerTechnicalTagsFixture.create(new ArrayList<>()))
             .build();
 
     private final Supporter supporter = Supporter.builder()

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/controller/read/RunnerPostControllerReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/controller/read/RunnerPostControllerReadTest.java
@@ -32,6 +32,7 @@ import touch.baton.domain.supporter.Supporter;
 import touch.baton.domain.supporter.repository.SupporterRepository;
 import touch.baton.domain.supporter.vo.ReviewCount;
 import touch.baton.domain.technicaltag.SupporterTechnicalTags;
+import touch.baton.fixture.domain.RunnerTechnicalTagsFixture;
 
 import java.util.ArrayList;
 
@@ -85,6 +86,7 @@ class RunnerPostControllerReadTest {
 
     private final Runner runner = Runner.builder()
             .member(runnerMember)
+            .runnerTechnicalTags(RunnerTechnicalTagsFixture.create(new ArrayList<>()))
             .build();
 
     private final Supporter supporter = Supporter.builder()

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostRepositoryDeleteTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostRepositoryDeleteTest.java
@@ -22,6 +22,7 @@ import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.PullRequestUrl;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
 import touch.baton.domain.tag.RunnerPostTags;
+import touch.baton.fixture.domain.RunnerTechnicalTagsFixture;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -56,6 +57,7 @@ class RunnerPostRepositoryDeleteTest extends RepositoryTestConfig {
 
         final Runner runner = Runner.builder()
                 .member(saveMember)
+                .runnerTechnicalTags(RunnerTechnicalTagsFixture.create(new ArrayList<>()))
                 .build();
         final Runner saveRunner = runnerRepository.saveAndFlush(runner);
 

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostRepositoryReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostRepositoryReadTest.java
@@ -22,6 +22,7 @@ import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.PullRequestUrl;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
 import touch.baton.domain.tag.RunnerPostTags;
+import touch.baton.fixture.domain.RunnerTechnicalTagsFixture;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -56,7 +57,9 @@ class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
 
         final Runner runner = Runner.builder()
                 .member(saveMember)
+                .runnerTechnicalTags(RunnerTechnicalTagsFixture.create(new ArrayList<>()))
                 .build();
+
         final Runner saveRunner = runnerRepository.saveAndFlush(runner);
 
         final RunnerPost runnerPost = RunnerPost.builder()

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceReadTest.java
@@ -27,6 +27,7 @@ import touch.baton.domain.tag.Tag;
 import touch.baton.fixture.domain.MemberFixture;
 import touch.baton.fixture.domain.RunnerFixture;
 import touch.baton.fixture.domain.RunnerPostFixture;
+import touch.baton.fixture.domain.RunnerTechnicalTagsFixture;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -61,6 +62,7 @@ class RunnerPostServiceReadTest extends ServiceTestConfig {
 
         final Runner runner = Runner.builder()
                 .member(member)
+                .runnerTechnicalTags(RunnerTechnicalTagsFixture.create(new ArrayList<>()))
                 .build();
         runnerRepository.save(runner);
 

--- a/backend/baton/src/test/java/touch/baton/domain/tag/RunnerPostTagTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/tag/RunnerPostTagTest.java
@@ -23,6 +23,7 @@ import touch.baton.domain.supporter.Supporter;
 import touch.baton.domain.supporter.vo.ReviewCount;
 import touch.baton.domain.tag.exception.RunnerPostTagDomainException;
 import touch.baton.domain.technicaltag.SupporterTechnicalTags;
+import touch.baton.fixture.domain.RunnerTechnicalTagsFixture;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -56,6 +57,7 @@ class RunnerPostTagTest {
 
         private final Runner runner = Runner.builder()
                 .member(runnerMember)
+                .runnerTechnicalTags(RunnerTechnicalTagsFixture.create(new ArrayList<>()))
                 .build();
 
         private final Supporter supporter = Supporter.builder()

--- a/backend/baton/src/test/java/touch/baton/domain/tag/RunnerPostTagsTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/tag/RunnerPostTagsTest.java
@@ -11,8 +11,10 @@ import touch.baton.domain.member.vo.OauthId;
 import touch.baton.domain.member.vo.SocialId;
 import touch.baton.domain.runner.Runner;
 import touch.baton.domain.runnerpost.RunnerPost;
+import touch.baton.fixture.domain.RunnerTechnicalTagsFixture;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +36,7 @@ class RunnerPostTagsTest {
                 .build();
         Runner runner = Runner.builder()
                 .member(member)
+                .runnerTechnicalTags(RunnerTechnicalTagsFixture.create(new ArrayList<>()))
                 .build();
         final RunnerPost runnerpost = RunnerPost.newInstance("리뷰해주세요.", "제발요.", "https://github.com/cookienc", LocalDateTime.of(2099, 12, 12, 0, 0), runner);
 

--- a/backend/baton/src/test/java/touch/baton/domain/tag/repository/RunnerPostTagRepositoryTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/tag/repository/RunnerPostTagRepositoryTest.java
@@ -26,6 +26,7 @@ import touch.baton.domain.runnerpost.vo.ReviewStatus;
 import touch.baton.domain.tag.RunnerPostTag;
 import touch.baton.domain.tag.RunnerPostTags;
 import touch.baton.domain.tag.Tag;
+import touch.baton.fixture.domain.RunnerTechnicalTagsFixture;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -66,6 +67,7 @@ class RunnerPostTagRepositoryTest extends RepositoryTestConfig {
 
         final Runner runner = Runner.builder()
                 .member(saveMember)
+                .runnerTechnicalTags(RunnerTechnicalTagsFixture.create(new ArrayList<>()))
                 .build();
         final Runner saveRunner = runnerRepository.saveAndFlush(runner);
 
@@ -118,7 +120,9 @@ class RunnerPostTagRepositoryTest extends RepositoryTestConfig {
 
         final Runner runner = Runner.builder()
                 .member(saveMember)
+                .runnerTechnicalTags(RunnerTechnicalTagsFixture.create(new ArrayList<>()))
                 .build();
+
         final Runner saveRunner = runnerRepository.saveAndFlush(runner);
 
         final LocalDateTime deadline = LocalDateTime.now();

--- a/backend/baton/src/test/java/touch/baton/fixture/domain/RunnerFixture.java
+++ b/backend/baton/src/test/java/touch/baton/fixture/domain/RunnerFixture.java
@@ -3,6 +3,12 @@ package touch.baton.fixture.domain;
 import touch.baton.domain.common.vo.Introduction;
 import touch.baton.domain.member.Member;
 import touch.baton.domain.runner.Runner;
+import touch.baton.domain.technicaltag.RunnerTechnicalTag;
+import touch.baton.domain.technicaltag.RunnerTechnicalTags;
+import touch.baton.domain.technicaltag.TechnicalTag;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static touch.baton.fixture.vo.IntroductionFixture.introduction;
 
@@ -17,10 +23,39 @@ public abstract class RunnerFixture {
         return Runner.builder()
                 .introduction(introduction)
                 .member(member)
+                .runnerTechnicalTags(new RunnerTechnicalTags(new ArrayList<>()))
+                .build();
+    }
+
+    public static Runner create(final Introduction introduction,
+                                final Member member,
+                                final RunnerTechnicalTags runnerTechnicalTags
+    ) {
+        return Runner.builder()
+                .introduction(introduction)
+                .member(member)
+                .runnerTechnicalTags(runnerTechnicalTags)
                 .build();
     }
 
     public static Runner createRunner(final Member member) {
-        return create(introduction("안녕하세요."), member);
+        return create(introduction("안녕하세요."), member, new RunnerTechnicalTags(new ArrayList<>()));
+    }
+
+    public static Runner createRunner(final Member member, final List<TechnicalTag> technicalTags) {
+        final Runner runner = create(introduction("안녕하세요."), member);
+
+        final List<RunnerTechnicalTag> runnerTechnicalTags = technicalTags.stream()
+                .map(technicalTag -> RunnerTechnicalTag.builder()
+                        .technicalTag(technicalTag)
+                        .runner(runner)
+                        .build())
+                .toList();
+
+        return Runner.builder()
+                .runnerTechnicalTags(new RunnerTechnicalTags(runnerTechnicalTags))
+                .introduction(runner.getIntroduction())
+                .member(runner.getMember())
+                .build();
     }
 }

--- a/backend/baton/src/test/java/touch/baton/fixture/domain/RunnerTechnicalTagsFixture.java
+++ b/backend/baton/src/test/java/touch/baton/fixture/domain/RunnerTechnicalTagsFixture.java
@@ -1,0 +1,29 @@
+package touch.baton.fixture.domain;
+
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.technicaltag.RunnerTechnicalTag;
+import touch.baton.domain.technicaltag.RunnerTechnicalTags;
+import touch.baton.domain.technicaltag.TechnicalTag;
+
+import java.util.List;
+
+public abstract class RunnerTechnicalTagsFixture {
+
+    private RunnerTechnicalTagsFixture() {
+    }
+
+    public static RunnerTechnicalTags create(final List<RunnerTechnicalTag> runnerTechnicalTags) {
+        return new RunnerTechnicalTags(runnerTechnicalTags);
+    }
+
+    public static RunnerTechnicalTags create(final Runner runner, final List<TechnicalTag> technicalTags) {
+        final List<RunnerTechnicalTag> runnerTechnicalTags = technicalTags.stream()
+                .map(technicalTag -> RunnerTechnicalTag.builder()
+                        .technicalTag(technicalTag)
+                        .runner(runner)
+                        .build())
+                .toList();
+
+        return new RunnerTechnicalTags(runnerTechnicalTags);
+    }
+}


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #274

## 참고사항
- 러너 본인 프로필 조회 API 구현
- 인수 테스트 데이터 초기화를 위한 AssuredTestExecutionListener 추가
- 러너 본인 프로필 조회 adoc 작성
- Runner에 RunnerTechnicalTags 추가 (Supporter는 기존에 있었습니다.)
  - 관련 테스트 수정 및 픽스처 추가
