### PR TITLE
만들어진 restdocs 파일을 src/resources/static/docs/ 하위로 이동

### DIFF
--- a/backend/baton/.gitignore
+++ b/backend/baton/.gitignore
@@ -180,3 +180,4 @@ gradle-app.setting
 
 src/main/resources/application-deploy.yml
 src/main/resources/application-dev.yml
+src/main/resources/static/docs/**

--- a/backend/baton/build.gradle
+++ b/backend/baton/build.gradle
@@ -73,5 +73,23 @@ tasks.register('copySecret', Copy) {
 tasks.named('asciidoctor') {
 	inputs.dir snippetsDir
 	configurations 'asciidoctorExt'
+	sources {
+		include("**/index.adoc")
+	}
+	baseDirFollowsSourceFile()
 	dependsOn test
+}
+
+asciidoctor.doFirst {
+	delete file('src/main/resources/static/docs')
+}
+
+task copyDocument(type: Copy) {
+	dependsOn asciidoctor
+	from file('build/docs/asciidoc')
+	into file('src/main/resources/static/docs')
+}
+
+build {
+	dependsOn copyDocument
 }

--- a/backend/baton/src/docs/asciidoc/MemberLoginProfileReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/MemberLoginProfileReadApi.adoc
@@ -1,7 +1,7 @@
 ifndef::snippets[]
 :snippets: ../../../build/generated-snippets
 endif::[]
-:doctype: investment
+:doctype: book
 :icons: font
 :source-highlighter: highlight.js
 :toc: left
@@ -10,18 +10,18 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-== *로그인된 사용자 프로필 조회*
+=== *로그인된 사용자 프로필 조회*
 
-=== *로그인된 사용자 프로필 조회 API*
+==== *로그인된 사용자 프로필 조회 API*
 
-==== *Http Request*
+===== *Http Request*
 include::{snippets}/../../build/generated-snippets/member-login-profile-read-api-test/read-login-member-by-access-token/http-request.adoc[]
 
-==== *Http Request Headers*
+===== *Http Request Headers*
 include::{snippets}/../../build/generated-snippets/member-login-profile-read-api-test/read-login-member-by-access-token/request-headers.adoc[]
 
-==== *Http Response*
+===== *Http Response*
 include::{snippets}/../../build/generated-snippets/member-login-profile-read-api-test/read-login-member-by-access-token/http-response.adoc[]
 
-==== *Http Response Fields*
+===== *Http Response Fields*
 include::{snippets}/../../build/generated-snippets/member-login-profile-read-api-test/read-login-member-by-access-token/response-fields.adoc[]

--- a/backend/baton/src/docs/asciidoc/MemberLoginProfileReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/MemberLoginProfileReadApi.adoc
@@ -5,7 +5,7 @@ endif::[]
 :icons: font
 :source-highlighter: highlight.js
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :sectlinks:
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response

--- a/backend/baton/src/docs/asciidoc/RunnerProfileReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerProfileReadApi.adoc
@@ -1,7 +1,7 @@
 ifndef::snippets[]
 :snippets: ../../../build/generated-snippets
 endif::[]
-:doctype: investment
+:doctype: book
 :icons: font
 :source-highlighter: highlight.js
 :toc: left
@@ -10,29 +10,29 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-== *러너 프로필 조회*
+=== *러너 프로필 조회*
 
-=== *러너 프로필 조회 API*
+==== *러너 프로필 조회 API*
 
-==== *Http Request*
+===== *Http Request*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-runner-profile/http-request.adoc[]
 
-==== *Http Response*
+===== *Http Response*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-runner-profile/http-response.adoc[]
 
-==== *Http Response Fields*
+===== *Http Response Fields*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-runner-profile/response-fields.adoc[]
 
-=== *러너 마이페이지 프로필 조회 API*
+==== *러너 마이페이지 프로필 조회 API*
 
-==== *Http Request*
+===== *Http Request*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/http-request.adoc[]
 
-==== *Http Request Headers*
+===== *Http Request Headers*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/request-headers.adoc[]
 
-==== *Http Response*
+===== *Http Response*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/http-response.adoc[]
 
-==== *Http Response Fields*
+===== *Http Response Fields*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/response-fields.adoc[]

--- a/backend/baton/src/docs/asciidoc/RunnerProfileReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerProfileReadApi.adoc
@@ -5,7 +5,7 @@ endif::[]
 :icons: font
 :source-highlighter: highlight.js
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :sectlinks:
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response

--- a/backend/baton/src/docs/asciidoc/RunnerProfileReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerProfileReadApi.adoc
@@ -15,13 +15,13 @@ endif::[]
 === *러너 프로필 조회 API*
 
 ==== *Http Request*
-include::{snippets}/../../build/generated-snippets/runner-profile-read-test/read-runner-profile/http-request.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-runner-profile/http-request.adoc[]
 
 ==== *Http Response*
-include::{snippets}/../../build/generated-snippets/runner-profile-read-test/read-runner-profile/http-response.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-runner-profile/http-response.adoc[]
 
 ==== *Http Response Fields*
-include::{snippets}/../../build/generated-snippets/runner-profile-read-test/read-runner-profile/response-fields.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-runner-profile/response-fields.adoc[]
 
 === *러너 마이페이지 프로필 조회 API*
 

--- a/backend/baton/src/docs/asciidoc/SupporterProfileUpdateApi.adoc
+++ b/backend/baton/src/docs/asciidoc/SupporterProfileUpdateApi.adoc
@@ -5,7 +5,7 @@ endif::[]
 :icons: font
 :source-highlighter: highlight.js
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :sectlinks:
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response

--- a/backend/baton/src/docs/asciidoc/SupporterProfileUpdateApi.adoc
+++ b/backend/baton/src/docs/asciidoc/SupporterProfileUpdateApi.adoc
@@ -1,7 +1,7 @@
 ifndef::snippets[]
 :snippets: ../../../build/generated-snippets
 endif::[]
-:doctype: investment
+:doctype: book
 :icons: font
 :source-highlighter: highlight.js
 :toc: left
@@ -10,21 +10,21 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-== *서포터 프로필 수정*
+=== *서포터 프로필 수정*
 
-=== *서포터 프로필 수정 API*
+==== *서포터 프로필 수정 API*
 
-==== *Http Request*
+===== *Http Request*
 include::{snippets}/../../build/generated-snippets/supporter-profile-update-api-test/update-supporter-profile/http-request.adoc[]
 
-==== *Http Request Headers*
+===== *Http Request Headers*
 include::{snippets}/../../build/generated-snippets/supporter-profile-update-api-test/update-supporter-profile/request-headers.adoc[]
 
-==== *Http Request Body*
+===== *Http Request Body*
 include::{snippets}/../../build/generated-snippets/supporter-profile-update-api-test/update-supporter-profile/request-body.adoc[]
 
-==== *Http Response*
+===== *Http Response*
 include::{snippets}/../../build/generated-snippets/supporter-profile-update-api-test/update-supporter-profile/http-response.adoc[]
 
-==== *Http Response Headers*
+===== *Http Response Headers*
 include::{snippets}/../../build/generated-snippets/supporter-profile-update-api-test/update-supporter-profile/response-headers.adoc[]

--- a/backend/baton/src/docs/asciidoc/index.adoc
+++ b/backend/baton/src/docs/asciidoc/index.adoc
@@ -5,7 +5,7 @@ endif::[]
 :icons: font
 :source-highlighter: highlight.js
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :sectlinks:
 
 = Baton-API

--- a/backend/baton/src/docs/asciidoc/index.adoc
+++ b/backend/baton/src/docs/asciidoc/index.adoc
@@ -10,11 +10,11 @@ endif::[]
 
 = Baton-API
 
-== *사용자 API*
+== *[사용자(러너와 서포터 공통)]*
 include::MemberLoginProfileReadApi.adoc[]
 
-== *러너 API*
+== *[ 러너 ]*
 include::RunnerProfileReadApi.adoc[]
 
-== *서포터 API*
+== *[ 서포터 ]*
 include::SupporterProfileUpdateApi.adoc[]

--- a/backend/baton/src/docs/asciidoc/index.adoc
+++ b/backend/baton/src/docs/asciidoc/index.adoc
@@ -1,0 +1,20 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+= Baton-API
+
+== *사용자 API*
+include::MemberLoginProfileReadApi.adoc[]
+
+== *러너 API*
+include::RunnerProfileReadApi.adoc[]
+
+== *서포터 API*
+include::SupporterProfileUpdateApi.adoc[]


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolve #326

## 참고사항
- 나눠진 adoc 파일들을 하나로 합치고 resources/static/docs/index.html로 옮기는 기능을 만들었습니다. 이제 url/docs/index.html을 하면 restDocs를 볼 수 있습니다.
- 이를 위해 build.gradle에 설정을 추가했습니다.

```groovy
tasks.named('asciidoctor') {
	inputs.dir snippetsDir
	configurations 'asciidoctorExt'
	sources {									// index.adoc을 인식해줍니다.
		include("**/index.adoc")
	}
	baseDirFollowsSourceFile()
	dependsOn test 						
}

asciidoctor.doFirst {	// asciidoctor가 동작할 때 처음으로 기존에 있던 restdocs를 지웁니다.
	delete file('src/main/resources/static/docs')
}

task copyDocument(type: Copy) {		// asciidoctor가 동작할 때 합쳐진 파일을 static/docs로 옮겨요
	dependsOn asciidoctor
	from file('build/docs/asciidoc')
	into file('src/main/resources/static/docs')
}

build {
	dependsOn copyDocument 	// 빌드할 때 copyDocument가 동작합니다.
}
```
- src/docs/asciidoc/index.adoc 생성. 파일 안에 보시고 알잘딱깔센으로 카데고리 나눠서 만드신 adoc 파일 집어 넣으면 asciidoctor가 실행될 때 index.html에 같이 포함시켜줍니다.
