### PR TITLE
서포터의 리뷰 완료한 게시글 조회 API 구현

### DIFF
--- a/backend/baton/.gitignore
+++ b/backend/baton/.gitignore
@@ -180,3 +180,4 @@ gradle-app.setting
 
 src/main/resources/application-deploy.yml
 src/main/resources/application-dev.yml
+src/main/resources/static/docs/**

--- a/backend/baton/build.gradle
+++ b/backend/baton/build.gradle
@@ -73,5 +73,23 @@ tasks.register('copySecret', Copy) {
 tasks.named('asciidoctor') {
 	inputs.dir snippetsDir
 	configurations 'asciidoctorExt'
+	sources {
+		include("**/index.adoc")
+	}
+	baseDirFollowsSourceFile()
 	dependsOn test
+}
+
+asciidoctor.doFirst {
+	delete file('src/main/resources/static/docs')
+}
+
+task copyDocument(type: Copy) {
+	dependsOn asciidoctor
+	from file('build/docs/asciidoc')
+	into file('src/main/resources/static/docs')
+}
+
+build {
+	dependsOn copyDocument
 }

--- a/backend/baton/src/docs/asciidoc/MemberLoginProfileReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/MemberLoginProfileReadApi.adoc
@@ -1,27 +1,27 @@
 ifndef::snippets[]
 :snippets: ../../../build/generated-snippets
 endif::[]
-:doctype: investment
+:doctype: book
 :icons: font
 :source-highlighter: highlight.js
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :sectlinks:
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-== *로그인된 사용자 프로필 조회*
+=== *로그인된 사용자 프로필 조회*
 
-=== *로그인된 사용자 프로필 조회 API*
+==== *로그인된 사용자 프로필 조회 API*
 
-==== *Http Request*
+===== *Http Request*
 include::{snippets}/../../build/generated-snippets/member-login-profile-read-api-test/read-login-member-by-access-token/http-request.adoc[]
 
-==== *Http Request Headers*
+===== *Http Request Headers*
 include::{snippets}/../../build/generated-snippets/member-login-profile-read-api-test/read-login-member-by-access-token/request-headers.adoc[]
 
-==== *Http Response*
+===== *Http Response*
 include::{snippets}/../../build/generated-snippets/member-login-profile-read-api-test/read-login-member-by-access-token/http-response.adoc[]
 
-==== *Http Response Fields*
+===== *Http Response Fields*
 include::{snippets}/../../build/generated-snippets/member-login-profile-read-api-test/read-login-member-by-access-token/response-fields.adoc[]

--- a/backend/baton/src/docs/asciidoc/RunnerLoginProfileReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerLoginProfileReadApi.adoc
@@ -10,29 +10,18 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-== *러너 프로필 조회*
+=== *로그인된 러너 프로필 조회*
 
-=== *러너 프로필 조회 API*
+==== *로그인된 러너 마이페이지 프로필 조회 API*
 
-==== *Http Request*
-include::{snippets}/../../build/generated-snippets/runner-profile-read-test/read-runner-profile/http-request.adoc[]
-
-==== *Http Response*
-include::{snippets}/../../build/generated-snippets/runner-profile-read-test/read-runner-profile/http-response.adoc[]
-
-==== *Http Response Fields*
-include::{snippets}/../../build/generated-snippets/runner-profile-read-test/read-runner-profile/response-fields.adoc[]
-
-=== *러너 마이페이지 프로필 조회 API*
-
-==== *Http Request*
+===== *Http Request*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/http-request.adoc[]
 
-==== *Http Request Headers*
+===== *Http Request Headers*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/request-headers.adoc[]
 
-==== *Http Response*
+===== *Http Response*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/http-response.adoc[]
 
-==== *Http Response Fields*
+===== *Http Response Fields*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/response-fields.adoc[]

--- a/backend/baton/src/docs/asciidoc/RunnerPostReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerPostReadApi.adoc
@@ -1,0 +1,27 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 3
+:sectlinks:
+:operation-http-request-title: Example Request
+:operation-http-response-title: Example Response
+
+=== *러너 게시글 조회*
+
+==== *서포터가 연관된 러너 게시글 조회 API*
+
+===== *Http Request*
+include::{snippets}/../../build/generated-snippets/runner-post-read-api-test/read-referenced-by-supporter/http-request.adoc[]
+
+===== *Http Request Query Parameters*
+include::{snippets}/../../build/generated-snippets/runner-post-read-api-test/read-referenced-by-supporter/query-parameters.adoc[]
+
+===== *Http Response*
+include::{snippets}/../../build/generated-snippets/runner-post-read-api-test/read-referenced-by-supporter/http-response.adoc[]
+
+===== *Http Response Fields*
+include::{snippets}/../../build/generated-snippets/runner-post-read-api-test/read-referenced-by-supporter/response-fields.adoc[]

--- a/backend/baton/src/docs/asciidoc/RunnerProfileReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerProfileReadApi.adoc
@@ -1,38 +1,38 @@
 ifndef::snippets[]
 :snippets: ../../../build/generated-snippets
 endif::[]
-:doctype: investment
+:doctype: book
 :icons: font
 :source-highlighter: highlight.js
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :sectlinks:
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-== *러너 프로필 조회*
+=== *러너 프로필 조회*
 
-=== *러너 프로필 조회 API*
+==== *러너 프로필 조회 API*
 
-==== *Http Request*
-include::{snippets}/../../build/generated-snippets/runner-profile-read-test/read-runner-profile/http-request.adoc[]
+===== *Http Request*
+include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-runner-profile/http-request.adoc[]
 
-==== *Http Response*
-include::{snippets}/../../build/generated-snippets/runner-profile-read-test/read-runner-profile/http-response.adoc[]
+===== *Http Response*
+include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-runner-profile/http-response.adoc[]
 
-==== *Http Response Fields*
-include::{snippets}/../../build/generated-snippets/runner-profile-read-test/read-runner-profile/response-fields.adoc[]
+===== *Http Response Fields*
+include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-runner-profile/response-fields.adoc[]
 
-=== *러너 마이페이지 프로필 조회 API*
+==== *러너 마이페이지 프로필 조회 API*
 
-==== *Http Request*
+===== *Http Request*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/http-request.adoc[]
 
-==== *Http Request Headers*
+===== *Http Request Headers*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/request-headers.adoc[]
 
-==== *Http Response*
+===== *Http Response*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/http-response.adoc[]
 
-==== *Http Response Fields*
+===== *Http Response Fields*
 include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-my-profile-by-token/response-fields.adoc[]

--- a/backend/baton/src/docs/asciidoc/RunnerProfileReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerProfileReadApi.adoc
@@ -15,13 +15,13 @@ endif::[]
 === *러너 프로필 조회 API*
 
 ==== *Http Request*
-include::{snippets}/../../build/generated-snippets/runner-profile-read-test/read-runner-profile/http-request.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-runner-profile/http-request.adoc[]
 
 ==== *Http Response*
-include::{snippets}/../../build/generated-snippets/runner-profile-read-test/read-runner-profile/http-response.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-runner-profile/http-response.adoc[]
 
 ==== *Http Response Fields*
-include::{snippets}/../../build/generated-snippets/runner-profile-read-test/read-runner-profile/response-fields.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-profile-read-api-test/read-runner-profile/response-fields.adoc[]
 
 === *러너 마이페이지 프로필 조회 API*
 

--- a/backend/baton/src/docs/asciidoc/RunnerProfileUpdateApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerProfileUpdateApi.adoc
@@ -1,0 +1,30 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+:doctype: investment
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 2
+:sectlinks:
+:operation-http-request-title: Example Request
+:operation-http-response-title: Example Response
+
+== *러너 프로필 수정*
+
+=== *러너 프로필 수정 API*
+
+==== *Http Request*
+include::{snippets}/../../build/generated-snippets/runner-profile-update-api-test/update-runner-profile/http-request.adoc[]
+
+==== *Http Request Headers*
+include::{snippets}/../../build/generated-snippets/runner-profile-update-api-test/update-runner-profile/request-headers.adoc[]
+
+==== *Http Request Body*
+include::{snippets}/../../build/generated-snippets/runner-profile-update-api-test/update-runner-profile/request-body.adoc[]
+
+==== *Http Response*
+include::{snippets}/../../build/generated-snippets/runner-profile-update-api-test/update-runner-profile/http-response.adoc[]
+
+==== *Http Response Headers*
+include::{snippets}/../../build/generated-snippets/runner-profile-update-api-test/update-runner-profile/response-headers.adoc[]

--- a/backend/baton/src/docs/asciidoc/SupporterProfileUpdateApi.adoc
+++ b/backend/baton/src/docs/asciidoc/SupporterProfileUpdateApi.adoc
@@ -1,30 +1,30 @@
 ifndef::snippets[]
 :snippets: ../../../build/generated-snippets
 endif::[]
-:doctype: investment
+:doctype: book
 :icons: font
 :source-highlighter: highlight.js
 :toc: left
-:toclevels: 2
+:toclevels: 3
 :sectlinks:
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-== *서포터 프로필 수정*
+=== *서포터 프로필 수정*
 
-=== *서포터 프로필 수정 API*
+==== *서포터 프로필 수정 API*
 
-==== *Http Request*
+===== *Http Request*
 include::{snippets}/../../build/generated-snippets/supporter-profile-update-api-test/update-supporter-profile/http-request.adoc[]
 
-==== *Http Request Headers*
+===== *Http Request Headers*
 include::{snippets}/../../build/generated-snippets/supporter-profile-update-api-test/update-supporter-profile/request-headers.adoc[]
 
-==== *Http Request Body*
+===== *Http Request Body*
 include::{snippets}/../../build/generated-snippets/supporter-profile-update-api-test/update-supporter-profile/request-body.adoc[]
 
-==== *Http Response*
+===== *Http Response*
 include::{snippets}/../../build/generated-snippets/supporter-profile-update-api-test/update-supporter-profile/http-response.adoc[]
 
-==== *Http Response Headers*
+===== *Http Response Headers*
 include::{snippets}/../../build/generated-snippets/supporter-profile-update-api-test/update-supporter-profile/response-headers.adoc[]

--- a/backend/baton/src/docs/asciidoc/index.adoc
+++ b/backend/baton/src/docs/asciidoc/index.adoc
@@ -1,0 +1,20 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 3
+:sectlinks:
+
+= Baton-API
+
+== *[사용자(러너와 서포터 공통)]*
+include::MemberLoginProfileReadApi.adoc[]
+
+== *[ 러너 ]*
+include::RunnerProfileReadApi.adoc[]
+
+== *[ 서포터 ]*
+include::SupporterProfileUpdateApi.adoc[]

--- a/backend/baton/src/main/java/touch/baton/config/converter/ConverterConfig.java
+++ b/backend/baton/src/main/java/touch/baton/config/converter/ConverterConfig.java
@@ -23,6 +23,7 @@ public class ConverterConfig implements WebMvcConfigurer {
     public void addFormatters(final FormatterRegistry registry) {
         registry.addConverter(new StringDateToLocalDateTimeConverter(DEFAULT_DATE_TIME_FORMAT, KOREA_TIME_ZONE));
         registry.addConverter(new OauthTypeConverter());
+        registry.addConverter(new ReviewStatusConverter());
     }
 
     @Bean

--- a/backend/baton/src/main/java/touch/baton/config/converter/ReviewStatusConverter.java
+++ b/backend/baton/src/main/java/touch/baton/config/converter/ReviewStatusConverter.java
@@ -1,0 +1,12 @@
+package touch.baton.config.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import touch.baton.domain.runnerpost.vo.ReviewStatus;
+
+public class ReviewStatusConverter implements Converter<String, ReviewStatus> {
+
+    @Override
+    public ReviewStatus convert(final String source) {
+        return ReviewStatus.from(source);
+    }
+}

--- a/backend/baton/src/main/java/touch/baton/domain/common/response/PageResponse.java
+++ b/backend/baton/src/main/java/touch/baton/domain/common/response/PageResponse.java
@@ -1,0 +1,38 @@
+package touch.baton.domain.common.response;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(List<T> data,
+                              PageInfo pageInfo
+) {
+
+    public static <T> PageResponse<T> from(final Page<T> page) {
+        return new PageResponse<>(page.getContent(), PageInfo.from(page));
+    }
+
+    public record PageInfo(boolean isFirst,
+                           boolean isLast,
+                           boolean hasNext,
+                           int totalPages,
+                           long totalElements,
+                           int currentPage,
+                           int currentSize
+    ) {
+
+        private static final int START_PAGE_NUMBER = 1;
+
+        public static <T> PageInfo from(final Page<T> page) {
+            return new PageInfo(
+                    page.isFirst(),
+                    page.isLast(),
+                    page.hasNext(),
+                    page.getTotalPages(),
+                    page.getTotalElements(),
+                    page.getNumber() + START_PAGE_NUMBER,
+                    page.getSize()
+            );
+        }
+    }
+}

--- a/backend/baton/src/main/java/touch/baton/domain/common/vo/Introduction.java
+++ b/backend/baton/src/main/java/touch/baton/domain/common/vo/Introduction.java
@@ -5,6 +5,10 @@ import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+import java.util.Objects;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -14,10 +18,17 @@ import static lombok.AccessLevel.PROTECTED;
 @Embeddable
 public class Introduction {
 
+    private static final String DEFAULT_VALUE = "'안녕하세요.'";
+
+    @ColumnDefault(DEFAULT_VALUE)
     @Column(name = "introduction", nullable = true)
     private String value;
 
     public Introduction(final String value) {
         this.value = value;
+    }
+
+    public static String getDefaultValue() {
+        return DEFAULT_VALUE;
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/oauth/controller/OauthController.java
+++ b/backend/baton/src/main/java/touch/baton/domain/oauth/controller/OauthController.java
@@ -38,7 +38,6 @@ public class OauthController {
                                       @RequestParam final String code
     ) {
         final String jwtToken = oauthService.login(oauthType, code);
-        System.out.println(jwtToken);
 
         return ResponseEntity.ok()
                 .header(AUTHORIZATION, jwtToken)

--- a/backend/baton/src/main/java/touch/baton/domain/oauth/controller/resolver/AuthRunnerPrincipalArgumentResolver.java
+++ b/backend/baton/src/main/java/touch/baton/domain/oauth/controller/resolver/AuthRunnerPrincipalArgumentResolver.java
@@ -4,6 +4,12 @@ import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import touch.baton.domain.common.exception.ClientErrorCode;
 import touch.baton.domain.common.vo.Introduction;
+import touch.baton.domain.member.Member;
+import touch.baton.domain.member.vo.Company;
+import touch.baton.domain.member.vo.GithubUrl;
+import touch.baton.domain.member.vo.ImageUrl;
+import touch.baton.domain.member.vo.MemberName;
+import touch.baton.domain.member.vo.OauthId;
 import touch.baton.domain.member.vo.SocialId;
 import touch.baton.domain.oauth.exception.OauthRequestException;
 import touch.baton.domain.oauth.repository.OauthRunnerRepository;
@@ -29,8 +35,15 @@ public class AuthRunnerPrincipalArgumentResolver extends UserPrincipalArgumentRe
     protected Object getGuest() {
         return Runner.builder()
                 .introduction(new Introduction("게스트"))
-                .member(null)
-                .build();
+                .member(Member.builder()
+                        .memberName(new MemberName("게스트"))
+                        .socialId(new SocialId("guestSocialId"))
+                        .oauthId(new OauthId("guestOauthId"))
+                        .githubUrl(new GithubUrl("guestGithubUrl"))
+                        .company(new Company("guestCompany"))
+                        .imageUrl(new ImageUrl("guestImageUrl"))
+                        .build()
+                );
     }
 
     @Override

--- a/backend/baton/src/main/java/touch/baton/domain/runner/Runner.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runner/Runner.java
@@ -13,6 +13,8 @@ import lombok.NoArgsConstructor;
 import touch.baton.domain.common.BaseEntity;
 import touch.baton.domain.common.vo.Introduction;
 import touch.baton.domain.member.Member;
+import touch.baton.domain.member.vo.Company;
+import touch.baton.domain.member.vo.MemberName;
 import touch.baton.domain.runner.exception.RunnerDomainException;
 import touch.baton.domain.technicaltag.RunnerTechnicalTag;
 import touch.baton.domain.technicaltag.RunnerTechnicalTags;
@@ -71,6 +73,25 @@ public class Runner extends BaseEntity {
 
     public void addAllRunnerTechnicalTags(final List<RunnerTechnicalTag> runnerTechnicalTags) {
         this.runnerTechnicalTags.addAll(runnerTechnicalTags);
+    }
+
+    public void updateIntroduction(final Introduction introduction) {
+        this.introduction = defaultIntroductionIfNull(introduction);
+    }
+
+    private Introduction defaultIntroductionIfNull(final Introduction introduction) {
+        if (Objects.isNull(introduction.getValue())) {
+            return new Introduction(introduction.getDefaultValue());
+        }
+        return introduction;
+    }
+
+    public void updateMemberName(final MemberName memberName) {
+        this.member.updateMemberName(memberName);
+    }
+
+    public void updateCompany(final Company company) {
+        this.member.updateCompany(company);
     }
 
     @Override

--- a/backend/baton/src/main/java/touch/baton/domain/runner/controller/RunnerProfileController.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runner/controller/RunnerProfileController.java
@@ -1,20 +1,26 @@
 package touch.baton.domain.runner.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 import touch.baton.domain.oauth.controller.resolver.AuthRunnerPrincipal;
 import touch.baton.domain.runner.Runner;
 import touch.baton.domain.runner.controller.response.RunnerMyProfileResponse;
 import touch.baton.domain.runner.controller.response.RunnerProfileResponse;
 import touch.baton.domain.runner.controller.response.RunnerResponse;
 import touch.baton.domain.runner.service.RunnerService;
+import touch.baton.domain.runner.service.dto.RunnerUpdateRequest;
 import touch.baton.domain.runnerpost.controller.response.RunnerPostResponse;
 import touch.baton.domain.runnerpost.service.RunnerPostService;
 
+import java.net.URI;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -41,9 +47,17 @@ public class RunnerProfileController {
         return ResponseEntity.ok(response);
     }
 
+    @PatchMapping("/me")
+    public ResponseEntity<Void> updateMyProfile(@AuthRunnerPrincipal final Runner runner,
+                                                @RequestBody @Valid final RunnerUpdateRequest runnerUpdateRequest) {
+        runnerService.updateRunner(runner, runnerUpdateRequest);
+        final URI redirectUri = UriComponentsBuilder.fromPath("/api/v1/profile/runner/me").build().toUri();
+        return ResponseEntity.noContent().location(redirectUri).build();
+    }
+
     @GetMapping("/{runnerId}")
     public ResponseEntity<RunnerProfileResponse.Detail> readRunnerProfile(@PathVariable Long runnerId) {
-        final Runner runner = runnerService.readRunnerById(runnerId);
+        final Runner runner = runnerService.readByRunnerId(runnerId);
         return ResponseEntity.ok(RunnerProfileResponse.Detail.from(runner));
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runner/controller/response/RunnerProfileResponse.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runner/controller/response/RunnerProfileResponse.java
@@ -1,9 +1,11 @@
 package touch.baton.domain.runner.controller.response;
 
+import touch.baton.domain.common.vo.Introduction;
 import touch.baton.domain.member.Member;
 import touch.baton.domain.runner.Runner;
 
 import java.util.List;
+import java.util.Objects;
 
 public record RunnerProfileResponse() {
 

--- a/backend/baton/src/main/java/touch/baton/domain/runner/service/RunnerService.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runner/service/RunnerService.java
@@ -3,9 +3,20 @@ package touch.baton.domain.runner.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import touch.baton.domain.common.vo.Introduction;
+import touch.baton.domain.common.vo.TagName;
+import touch.baton.domain.member.vo.Company;
+import touch.baton.domain.member.vo.MemberName;
 import touch.baton.domain.runner.Runner;
 import touch.baton.domain.runner.exception.RunnerBusinessException;
 import touch.baton.domain.runner.repository.RunnerRepository;
+import touch.baton.domain.runner.service.dto.RunnerUpdateRequest;
+import touch.baton.domain.technicaltag.RunnerTechnicalTag;
+import touch.baton.domain.technicaltag.TechnicalTag;
+import touch.baton.domain.technicaltag.repository.RunnerTechnicalTagRepository;
+import touch.baton.domain.technicaltag.repository.TechnicalTagRepository;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -13,9 +24,52 @@ import touch.baton.domain.runner.repository.RunnerRepository;
 public class RunnerService {
 
     private final RunnerRepository runnerRepository;
+    private final RunnerTechnicalTagRepository runnerTechnicalTagRepository;
+    private final TechnicalTagRepository technicalTagRepository;
 
-    public Runner readRunnerById(final Long runnerId) {
+    public Runner readByRunnerId(final Long runnerId) {
         return runnerRepository.joinMemberByRunnerId(runnerId)
-                .orElseThrow(() -> new RunnerBusinessException("Runner가 존재하지 않습니다."));
+                .orElseThrow(() -> new RunnerBusinessException("Runner 가 존재하지 않습니다."));
+    }
+
+    @Transactional
+    public void updateRunner(Runner runner, RunnerUpdateRequest runnerUpdateRequest) {
+        runner.updateMemberName(new MemberName(runnerUpdateRequest.name()));
+        runner.updateCompany(new Company(runnerUpdateRequest.company()));
+        runner.updateIntroduction(new Introduction(runnerUpdateRequest.introduction()));
+        updateTechnicalTags(runner, runnerUpdateRequest.technicalTags());
+    }
+
+    private void updateTechnicalTags(final Runner runner, final List<String> technicalTags) {
+        runnerTechnicalTagRepository.deleteByRunner(runner);
+        createRunnerTechnicalTags(runner, technicalTags);
+    }
+
+    private List<RunnerTechnicalTag> createRunnerTechnicalTags(final Runner runner, final List<String> technicalTags) {
+        return technicalTags.stream()
+                .map(tagName -> createRunnerTechnicalTag(runner, new TagName(tagName)))
+                .toList();
+    }
+
+    private RunnerTechnicalTag createRunnerTechnicalTag(final Runner runner, final TagName tagName) {
+        final TechnicalTag technicalTag = findTechnicalTagIfExistElseCreate(tagName);
+        return createRunnerTechnicalTagAndSave(runner, technicalTag);
+    }
+
+    private TechnicalTag findTechnicalTagIfExistElseCreate(final TagName tagName) {
+        return technicalTagRepository.findByTagName(tagName)
+                .orElseGet(() -> technicalTagRepository.save(
+                        TechnicalTag.builder()
+                                .tagName(tagName)
+                                .build())
+                );
+    }
+
+    private RunnerTechnicalTag createRunnerTechnicalTagAndSave(final Runner runner, final TechnicalTag technicalTag) {
+        RunnerTechnicalTag runnerTechnicalTag = RunnerTechnicalTag.builder()
+                .runner(runner)
+                .technicalTag(technicalTag)
+                .build();
+        return runnerTechnicalTagRepository.save(runnerTechnicalTag);
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runner/service/dto/RunnerUpdateRequest.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runner/service/dto/RunnerUpdateRequest.java
@@ -1,0 +1,19 @@
+package touch.baton.domain.runner.service.dto;
+
+import touch.baton.domain.common.exception.validator.ValidNotNull;
+
+import java.util.List;
+
+import static touch.baton.domain.common.exception.ClientErrorCode.COMPANY_IS_NULL;
+import static touch.baton.domain.common.exception.ClientErrorCode.NAME_IS_NULL;
+import static touch.baton.domain.common.exception.ClientErrorCode.RUNNER_TECHNICAL_TAGS_ARE_NULL;
+
+public record RunnerUpdateRequest(@ValidNotNull(clientErrorCode = NAME_IS_NULL)
+                                  String name,
+                                  @ValidNotNull(clientErrorCode = COMPANY_IS_NULL)
+                                  String company,
+                                  String introduction,
+                                  @ValidNotNull(clientErrorCode = RUNNER_TECHNICAL_TAGS_ARE_NULL)
+                                  List<String> technicalTags
+) {
+}

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/RunnerPost.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/RunnerPost.java
@@ -34,6 +34,7 @@ import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
+import static touch.baton.domain.runnerpost.vo.ReviewStatus.*;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
@@ -168,7 +169,7 @@ public class RunnerPost extends BaseEntity {
                 .runner(runner)
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
                 .watchedCount(WatchedCount.zero())
-                .reviewStatus(ReviewStatus.NOT_STARTED)
+                .reviewStatus(NOT_STARTED)
                 .build();
     }
 
@@ -197,7 +198,18 @@ public class RunnerPost extends BaseEntity {
     }
 
     public void assignSupporter(final Supporter supporter) {
+        if (Objects.nonNull(this.supporter)) {
+            throw new RunnerPostDomainException("러너 게시글에 이미 서포터가 할당되어 있습니다.");
+        }
+        if (reviewStatus.isNotSameAsNotStarted()) {
+            throw new RunnerPostDomainException("러너 게시글은 이미 시작 중이거나 완료 되었습니다.");
+        }
+        if (deadline.isEnd()) {
+            throw new RunnerPostDomainException("러너 게시글은 이미 마감 기한이 종료되었습니다.");
+        }
+
         this.supporter = supporter;
+        this.reviewStatus = IN_PROGRESS;
     }
 
     public void increaseWatchedCount() {

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/RunnerPost.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/RunnerPost.java
@@ -34,7 +34,10 @@ import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
-import static touch.baton.domain.runnerpost.vo.ReviewStatus.*;
+import static touch.baton.domain.runnerpost.vo.ReviewStatus.DONE;
+import static touch.baton.domain.runnerpost.vo.ReviewStatus.IN_PROGRESS;
+import static touch.baton.domain.runnerpost.vo.ReviewStatus.NOT_STARTED;
+import static touch.baton.domain.runnerpost.vo.ReviewStatus.OVERDUE;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/RunnerPost.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/RunnerPost.java
@@ -199,19 +199,22 @@ public class RunnerPost extends BaseEntity {
 
     public void updateReviewStatus(final ReviewStatus other) {
         if (this.reviewStatus.isSame(NOT_STARTED) && other.isSame(IN_PROGRESS)) {
-            throw new RunnerPostDomainException("ReviewStatus 는 NOT_STARTED 에서 IN_PROGRESS 로 수정될 수 없습니다.");
+            throw new RunnerPostDomainException("ReviewStatus 를 수정하던 도중 NOT_STARTED 에서 IN_PROGRESS 로 리뷰 상태 정책을 원인으로 실패하였습니다.");
         }
         if (this.reviewStatus.isSame(NOT_STARTED) && other.isSame(DONE)) {
-            throw new RunnerPostDomainException("ReviewStatus 는 NOT_STARTED 에서 DONE 로 수정될 수 없습니다.");
+            throw new RunnerPostDomainException("ReviewStatus 를 수정하던 도중 NOT_STARTED 에서 DONE 으로 리뷰 상태 정책을 원인으로 실패하였습니다.");
         }
         if (this.reviewStatus.isSame(DONE) && other.isSame(NOT_STARTED)) {
-            throw new RunnerPostDomainException("ReviewStatus 는 DONE 에서 NOT_STARTED 로 수정될 수 없습니다.");
+            throw new RunnerPostDomainException("ReviewStatus 를 수정하던 도중 DONE 에서 NOT_STARTED 로 리뷰 상태 정책을 원인으로 실패하였습니다.");
         }
         if (this.reviewStatus.isSame(DONE) && other.isSame(IN_PROGRESS)) {
-            throw new RunnerPostDomainException("ReviewStatus 는 DONE 에서 IN_PROGRESS 로 수정될 수 없습니다.");
+            throw new RunnerPostDomainException("ReviewStatus 를 수정하던 도중 DONE 에서 IN_PROGRESS 로 리뷰 상태 정책을 원인으로 실패하였습니다.");
+        }
+        if (this.reviewStatus.isSame(DONE) && other.isSame(OVERDUE)) {
+            throw new RunnerPostDomainException("ReviewStatus 를 수정하던 도중 DONE 에서 OVERDUE 로 리뷰 상태 정책을 원인으로 실패하였습니다.");
         }
         if (this.reviewStatus.isSame(other)) {
-            throw new RunnerPostDomainException("ReviewStatus 는 같은 값으로 수정될 수 없습니다.");
+            throw new RunnerPostDomainException("ReviewStatus 를 수정하던 도중 같은 ReviewStatus 로 리뷰 상태 정책을 원인으로 실패하였습니다.");
         }
 
         this.reviewStatus = other;
@@ -219,13 +222,16 @@ public class RunnerPost extends BaseEntity {
 
     public void assignSupporter(final Supporter supporter) {
         if (Objects.nonNull(this.supporter)) {
-            throw new RunnerPostDomainException("러너 게시글에 이미 서포터가 할당되어 있습니다.");
+            throw new RunnerPostDomainException("Supporter 를 할당하던 도중 RunnerPost 에 이미 다른 Supporter 가 할당되어 있는 것을 원인으로 실패하였습니다.");
+        }
+        if (reviewStatus.isSame(OVERDUE)) {
+            throw new RunnerPostDomainException("Supporter 를 할당하던 도중 ReviewStatus 가 OVERDUE 상태가 원인으로 실패하였습니다.");
         }
         if (reviewStatus.isNotSameAsNotStarted()) {
-            throw new RunnerPostDomainException("러너 게시글은 이미 시작 중이거나 완료 되었습니다.");
+            throw new RunnerPostDomainException("Supporter 를 할당하던 도중 ReviewStatus 가 NOT_STARTED 상태가 아닌 것을 원인으로 실패하였습니다.");
         }
         if (deadline.isEnd()) {
-            throw new RunnerPostDomainException("러너 게시글은 이미 마감 기한이 종료되었습니다.");
+            throw new RunnerPostDomainException("Supporter 를 할당하던 도중 ReviewStatus 의 Deadline 이 현재 시간보다 과거인 것을 원인으로 실패하였습니다.");
         }
 
         this.supporter = supporter;

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/RunnerPost.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/RunnerPost.java
@@ -197,6 +197,26 @@ public class RunnerPost extends BaseEntity {
         this.deadline = deadline;
     }
 
+    public void updateReviewStatus(final ReviewStatus other) {
+        if (this.reviewStatus.isSame(NOT_STARTED) && other.isSame(IN_PROGRESS)) {
+            throw new RunnerPostDomainException("ReviewStatus 는 NOT_STARTED 에서 IN_PROGRESS 로 수정될 수 없습니다.");
+        }
+        if (this.reviewStatus.isSame(NOT_STARTED) && other.isSame(DONE)) {
+            throw new RunnerPostDomainException("ReviewStatus 는 NOT_STARTED 에서 DONE 로 수정될 수 없습니다.");
+        }
+        if (this.reviewStatus.isSame(DONE) && other.isSame(NOT_STARTED)) {
+            throw new RunnerPostDomainException("ReviewStatus 는 DONE 에서 NOT_STARTED 로 수정될 수 없습니다.");
+        }
+        if (this.reviewStatus.isSame(DONE) && other.isSame(IN_PROGRESS)) {
+            throw new RunnerPostDomainException("ReviewStatus 는 DONE 에서 IN_PROGRESS 로 수정될 수 없습니다.");
+        }
+        if (this.reviewStatus.isSame(other)) {
+            throw new RunnerPostDomainException("ReviewStatus 는 같은 값으로 수정될 수 없습니다.");
+        }
+
+        this.reviewStatus = other;
+    }
+
     public void assignSupporter(final Supporter supporter) {
         if (Objects.nonNull(this.supporter)) {
             throw new RunnerPostDomainException("러너 게시글에 이미 서포터가 할당되어 있습니다.");

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/RunnerPostController.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/RunnerPostController.java
@@ -138,14 +138,14 @@ public class RunnerPostController {
 
     @GetMapping("/search")
     public ResponseEntity<PageResponse<RunnerPostResponse.ReferencedBySupporter>> readReferencedBySupporter(
-            @PageableDefault(size = 10, page = 0, sort = "createdAt", direction = DESC) Pageable pageable,
+            @PageableDefault(size = 10, page = 1, sort = "createdAt", direction = DESC) final Pageable pageable,
             @RequestParam("supporterId") final Long supporterId,
             @RequestParam("reviewStatus") final ReviewStatus reviewStatus
     ) {
         final Page<RunnerPost> pageRunnerPosts = runnerPostService.readRunnerPostsBySupporterIdAndReviewStatus(pageable, supporterId, reviewStatus);
         final List<RunnerPost> foundRunnerPosts = pageRunnerPosts.getContent();
         final List<Integer> applicantCounts = collectApplicantCounts(pageRunnerPosts);
-        final List<RunnerPostResponse.ReferencedBySupporter> responses = IntStream.range(0, applicantCounts.size())
+        final List<RunnerPostResponse.ReferencedBySupporter> responses = IntStream.range(0, foundRunnerPosts.size())
                 .mapToObj(index -> {
                     final RunnerPost foundRunnerPost = foundRunnerPosts.get(index);
                     final Integer applicantCount = applicantCounts.get(index);
@@ -153,7 +153,7 @@ public class RunnerPostController {
                     return RunnerPostResponse.ReferencedBySupporter.from(foundRunnerPost, applicantCount);
                 }).toList();
 
-        final PageImpl<RunnerPostResponse.ReferencedBySupporter> pageResponse
+        final Page<RunnerPostResponse.ReferencedBySupporter> pageResponse
                 = new PageImpl<>(responses, pageable, pageRunnerPosts.getTotalPages());
 
         return ResponseEntity.ok(PageResponse.from(pageResponse));

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/RunnerPostController.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/RunnerPostController.java
@@ -150,7 +150,7 @@ public class RunnerPostController {
                     final RunnerPost foundRunnerPost = foundRunnerPosts.get(index);
                     final Integer applicantCount = applicantCounts.get(index);
 
-                    return RunnerPostResponse.ReferencedBySupporter.from(foundRunnerPost, applicantCount);
+                    return RunnerPostResponse.ReferencedBySupporter.of(foundRunnerPost, applicantCount);
                 }).toList();
 
         final Page<RunnerPostResponse.ReferencedBySupporter> pageResponse

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/RunnerPostController.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/RunnerPostController.java
@@ -2,6 +2,10 @@ package touch.baton.domain.runnerpost.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,8 +14,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
+import touch.baton.domain.common.response.PageResponse;
 import touch.baton.domain.oauth.controller.resolver.AuthRunnerPrincipal;
 import touch.baton.domain.runner.Runner;
 import touch.baton.domain.runnerpost.RunnerPost;
@@ -21,9 +27,13 @@ import touch.baton.domain.runnerpost.service.RunnerPostService;
 import touch.baton.domain.runnerpost.service.dto.RunnerPostCreateRequest;
 import touch.baton.domain.runnerpost.service.dto.RunnerPostCreateTestRequest;
 import touch.baton.domain.runnerpost.service.dto.RunnerPostUpdateRequest;
+import touch.baton.domain.runnerpost.vo.ReviewStatus;
 
 import java.net.URI;
 import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/posts/runner")
@@ -124,5 +134,36 @@ public class RunnerPostController {
                 .toList();
 
         return ResponseEntity.ok(RunnerPostReadResponses.NoFiltering.from(responses));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<PageResponse<RunnerPostResponse.ReferencedBySupporter>> readReferencedBySupporter(
+            @PageableDefault(size = 10, page = 0, sort = "createdAt", direction = DESC) Pageable pageable,
+            @RequestParam("supporterId") final Long supporterId,
+            @RequestParam("reviewStatus") final ReviewStatus reviewStatus
+    ) {
+        final Page<RunnerPost> pageRunnerPosts = runnerPostService.readRunnerPostsBySupporterIdAndReviewStatus(pageable, supporterId, reviewStatus);
+        final List<RunnerPost> foundRunnerPosts = pageRunnerPosts.getContent();
+        final List<Integer> applicantCounts = collectApplicantCounts(pageRunnerPosts);
+        final List<RunnerPostResponse.ReferencedBySupporter> responses = IntStream.range(0, applicantCounts.size())
+                .mapToObj(index -> {
+                    final RunnerPost foundRunnerPost = foundRunnerPosts.get(index);
+                    final Integer applicantCount = applicantCounts.get(index);
+
+                    return RunnerPostResponse.ReferencedBySupporter.from(foundRunnerPost, applicantCount);
+                }).toList();
+
+        final PageImpl<RunnerPostResponse.ReferencedBySupporter> pageResponse
+                = new PageImpl<>(responses, pageable, pageRunnerPosts.getTotalPages());
+
+        return ResponseEntity.ok(PageResponse.from(pageResponse));
+    }
+
+    private List<Integer> collectApplicantCounts(final Page<RunnerPost> pageRunnerPosts) {
+        final List<Long> runnerPostIds = pageRunnerPosts.stream()
+                .map(RunnerPost::getId)
+                .toList();
+
+        return runnerPostService.readCountsByRunnerPostIds(runnerPostIds);
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/response/RunnerPostResponse.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/response/RunnerPostResponse.java
@@ -114,4 +114,26 @@ public record RunnerPostResponse() {
                 .map(runnerPostTag -> runnerPostTag.getTag().getTagName().getValue())
                 .toList();
     }
+
+    public record ReferencedBySupporter(Long runnerPostId,
+                                        String title,
+                                        LocalDateTime deadline,
+                                        List<String> tags,
+                                        Integer watchedCount,
+                                        Integer applicantCount,
+                                        String reviewStatus
+    ) {
+
+        public static ReferencedBySupporter from(final RunnerPost runnerPost, Integer applicantCount) {
+            return new ReferencedBySupporter(
+                    runnerPost.getId(),
+                    runnerPost.getTitle().getValue(),
+                    runnerPost.getDeadline().getValue(),
+                    convertToTags(runnerPost),
+                    runnerPost.getWatchedCount().getValue(),
+                    applicantCount,
+                    runnerPost.getReviewStatus().name()
+            );
+        }
+    }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/response/RunnerPostResponse.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/response/RunnerPostResponse.java
@@ -119,8 +119,8 @@ public record RunnerPostResponse() {
                                         String title,
                                         LocalDateTime deadline,
                                         List<String> tags,
-                                        Integer watchedCount,
-                                        Integer applicantCount,
+                                        int watchedCount,
+                                        int applicantCount,
                                         String reviewStatus
     ) {
 

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/response/RunnerPostResponse.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/response/RunnerPostResponse.java
@@ -120,11 +120,11 @@ public record RunnerPostResponse() {
                                         LocalDateTime deadline,
                                         List<String> tags,
                                         int watchedCount,
-                                        int applicantCount,
+                                        long applicantCount,
                                         String reviewStatus
     ) {
 
-        public static ReferencedBySupporter of(final RunnerPost runnerPost, Integer applicantCount) {
+        public static ReferencedBySupporter of(final RunnerPost runnerPost, final int applicantCount) {
             return new ReferencedBySupporter(
                     runnerPost.getId(),
                     runnerPost.getTitle().getValue(),

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/response/RunnerPostResponse.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/response/RunnerPostResponse.java
@@ -124,7 +124,7 @@ public record RunnerPostResponse() {
                                         String reviewStatus
     ) {
 
-        public static ReferencedBySupporter from(final RunnerPost runnerPost, Integer applicantCount) {
+        public static ReferencedBySupporter of(final RunnerPost runnerPost, Integer applicantCount) {
             return new ReferencedBySupporter(
                     runnerPost.getId(),
                     runnerPost.getTitle().getValue(),

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/RunnerPostRepository.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/RunnerPostRepository.java
@@ -1,10 +1,13 @@
 package touch.baton.domain.runnerpost.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import touch.baton.domain.common.vo.Title;
 import touch.baton.domain.runnerpost.RunnerPost;
+import touch.baton.domain.runnerpost.vo.ReviewStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,6 +26,18 @@ public interface RunnerPostRepository extends JpaRepository<RunnerPost, Long> {
     List<RunnerPost> findAllByOrderByCreatedAtDesc();
 
     List<RunnerPost> findByRunnerId(Long runnerId);
+
+    @Query(countQuery = """
+            select count(1)
+            from RunnerPost rp
+            where rp.supporter.id = :supporterId
+            and rp.reviewStatus = :reviewStatus
+            """)
+    Page<RunnerPost> findBySupporterIdAndReviewStatus(final Pageable pageable,
+                                                      @Param("supporterId") final Long supporterId,
+                                                      @Param("reviewStatus") final ReviewStatus reviewStatus);
+
     List<RunnerPost> readBySupporterId(Long supporterId);
+
     Optional<RunnerPost> readByTitle(Title title);
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/service/RunnerPostService.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/service/RunnerPostService.java
@@ -1,6 +1,8 @@
 package touch.baton.domain.runnerpost.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import touch.baton.domain.common.vo.Contents;
@@ -15,8 +17,10 @@ import touch.baton.domain.runnerpost.service.dto.RunnerPostCreateTestRequest;
 import touch.baton.domain.runnerpost.service.dto.RunnerPostUpdateRequest;
 import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.PullRequestUrl;
+import touch.baton.domain.runnerpost.vo.ReviewStatus;
 import touch.baton.domain.supporter.Supporter;
 import touch.baton.domain.supporter.repository.SupporterRepository;
+import touch.baton.domain.supporter.repository.SupporterRunnerPostRepository;
 import touch.baton.domain.tag.RunnerPostTag;
 import touch.baton.domain.tag.Tag;
 import touch.baton.domain.tag.repository.RunnerPostTagRepository;
@@ -36,6 +40,7 @@ public class RunnerPostService {
     private final RunnerPostTagRepository runnerPostTagRepository;
     private final TagRepository tagRepository;
     private final SupporterRepository supporterRepository;
+    private final SupporterRunnerPostRepository supporterRunnerPostRepository;
 
     @Transactional
     public Long createRunnerPost(final Runner runner, final RunnerPostCreateRequest request) {
@@ -194,5 +199,16 @@ public class RunnerPostService {
 
     public List<RunnerPost> readRunnerPostsByRunnerId(final Long runnerId) {
         return runnerPostRepository.findByRunnerId(runnerId);
+    }
+
+    public Page<RunnerPost> readRunnerPostsBySupporterIdAndReviewStatus(final Pageable pageable,
+                                                                        final Long supporterId,
+                                                                        final ReviewStatus reviewStatus
+    ) {
+        return runnerPostRepository.findBySupporterIdAndReviewStatus(pageable, supporterId, reviewStatus);
+    }
+
+    public List<Integer> readCountsByRunnerPostIds(final List<Long> runnerPostIds) {
+        return supporterRunnerPostRepository.countByRunnerPostIdIn(runnerPostIds);
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/Deadline.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/Deadline.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+import static java.time.temporal.ChronoUnit.MINUTES;
 import static lombok.AccessLevel.PROTECTED;
 
 @EqualsAndHashCode
@@ -22,12 +23,16 @@ public class Deadline {
 
     public Deadline(final LocalDateTime value) {
         validateNotNull(value);
-        this.value = value;
+        this.value = value.truncatedTo(MINUTES);
     }
 
     private void validateNotNull(final LocalDateTime value) {
         if (Objects.isNull(value)) {
             throw new IllegalArgumentException("Deadline 객체 내부에 deadline 은 null 일 수 없습니다.");
         }
+    }
+
+    public boolean isEnd() {
+        return value.isBefore(LocalDateTime.now());
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/ReviewStatus.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/ReviewStatus.java
@@ -1,8 +1,18 @@
 package touch.baton.domain.runnerpost.vo;
 
+import static java.util.Locale.ENGLISH;
+
 public enum ReviewStatus {
 
     NOT_STARTED,
     IN_PROGRESS,
-    DONE
+    DONE;
+
+    public static ReviewStatus from(final String name) {
+        return ReviewStatus.valueOf(name.toUpperCase(ENGLISH));
+    }
+
+    public boolean isNotSameAsNotStarted() {
+        return this != NOT_STARTED;
+    }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/ReviewStatus.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/ReviewStatus.java
@@ -6,10 +6,15 @@ public enum ReviewStatus {
 
     NOT_STARTED,
     IN_PROGRESS,
-    DONE;
+    DONE,
+    OVERDUE;
 
     public static ReviewStatus from(final String name) {
         return ReviewStatus.valueOf(name.toUpperCase(ENGLISH));
+    }
+
+    public boolean isSame(final ReviewStatus reviewStatus) {
+        return this == reviewStatus;
     }
 
     public boolean isNotSameAsNotStarted() {

--- a/backend/baton/src/main/java/touch/baton/domain/supporter/Supporter.java
+++ b/backend/baton/src/main/java/touch/baton/domain/supporter/Supporter.java
@@ -112,7 +112,14 @@ public class Supporter extends BaseEntity {
     }
 
     public void updateIntroduction(final Introduction introduction) {
-        this.introduction = introduction;
+        this.introduction = defaultIntroductionIfNull(introduction);
+    }
+
+    private Introduction defaultIntroductionIfNull(final Introduction introduction) {
+        if (Objects.isNull(introduction.getValue())) {
+            return new Introduction(introduction.getDefaultValue());
+        }
+        return introduction;
     }
 
     @Override

--- a/backend/baton/src/main/java/touch/baton/domain/supporter/repository/SupporterRunnerPostRepository.java
+++ b/backend/baton/src/main/java/touch/baton/domain/supporter/repository/SupporterRunnerPostRepository.java
@@ -1,0 +1,12 @@
+package touch.baton.domain.supporter.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import touch.baton.domain.supporter.SupporterRunnerPost;
+
+import java.util.List;
+
+public interface SupporterRunnerPostRepository extends JpaRepository<SupporterRunnerPost, Long> {
+
+    List<Integer> countByRunnerPostIdIn(@Param("runnerPostIds") List<Long> runnerPostIds);
+}

--- a/backend/baton/src/main/java/touch/baton/domain/supporter/repository/SupporterRunnerPostRepository.java
+++ b/backend/baton/src/main/java/touch/baton/domain/supporter/repository/SupporterRunnerPostRepository.java
@@ -1,6 +1,7 @@
 package touch.baton.domain.supporter.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import touch.baton.domain.supporter.SupporterRunnerPost;
 
@@ -8,5 +9,11 @@ import java.util.List;
 
 public interface SupporterRunnerPostRepository extends JpaRepository<SupporterRunnerPost, Long> {
 
-    List<Integer> countByRunnerPostIdIn(@Param("runnerPostIds") List<Long> runnerPostIds);
+    @Query("""
+        select count(1)
+        from SupporterRunnerPost srp
+        group by srp.runnerPost.id
+        having srp.runnerPost.id in (:runnerPostIds)
+        """)
+    List<Integer> countByRunnerPostIdIn(@Param("runnerPostIds") final List<Long> runnerPostIds);
 }

--- a/backend/baton/src/main/java/touch/baton/domain/supporter/service/dto/SupporterUpdateRequest.java
+++ b/backend/baton/src/main/java/touch/baton/domain/supporter/service/dto/SupporterUpdateRequest.java
@@ -4,7 +4,9 @@ import touch.baton.domain.common.exception.validator.ValidNotNull;
 
 import java.util.List;
 
-import static touch.baton.domain.common.exception.ClientErrorCode.*;
+import static touch.baton.domain.common.exception.ClientErrorCode.COMPANY_IS_NULL;
+import static touch.baton.domain.common.exception.ClientErrorCode.NAME_IS_NULL;
+import static touch.baton.domain.common.exception.ClientErrorCode.SUPPORTER_TECHNICAL_TAGS_ARE_NULL;
 
 public record SupporterUpdateRequest(@ValidNotNull(clientErrorCode = NAME_IS_NULL)
                                      String name,
@@ -12,5 +14,6 @@ public record SupporterUpdateRequest(@ValidNotNull(clientErrorCode = NAME_IS_NUL
                                      String company,
                                      String introduction,
                                      @ValidNotNull(clientErrorCode = SUPPORTER_TECHNICAL_TAGS_ARE_NULL)
-                                     List<String> technicalTags) {
+                                     List<String> technicalTags
+) {
 }

--- a/backend/baton/src/main/java/touch/baton/domain/tag/RunnerPostTags.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/RunnerPostTags.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static jakarta.persistence.CascadeType.PERSIST;
 import static lombok.AccessLevel.PROTECTED;
@@ -29,5 +30,18 @@ public class RunnerPostTags {
 
     public void addAll(final List<RunnerPostTag> runnerPostTags) {
         this.runnerPostTags.addAll(runnerPostTags);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RunnerPostTags that = (RunnerPostTags) o;
+        return Objects.equals(runnerPostTags, that.runnerPostTags);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(runnerPostTags);
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/technicaltag/repository/RunnerTechnicalTagRepository.java
+++ b/backend/baton/src/main/java/touch/baton/domain/technicaltag/repository/RunnerTechnicalTagRepository.java
@@ -1,0 +1,15 @@
+package touch.baton.domain.technicaltag.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.technicaltag.RunnerTechnicalTag;
+
+public interface RunnerTechnicalTagRepository extends JpaRepository<RunnerTechnicalTag, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM RunnerTechnicalTag rt WHERE rt.runner = :runner")
+    int deleteByRunner(@Param("runner") final Runner runner);
+}

--- a/backend/baton/src/test/java/touch/baton/assure/common/AssuredSupport.java
+++ b/backend/baton/src/test/java/touch/baton/assure/common/AssuredSupport.java
@@ -4,6 +4,8 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 
+import java.util.Map;
+
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 public class AssuredSupport {
@@ -63,6 +65,17 @@ public class AssuredSupport {
                 .body(params)
                 .when().log().ifValidationFails()
                 .patch(uri)
+                .then().log().ifError()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> get(final String uri, final Map<String, Object> queryParams) {
+        return RestAssured
+                .given().log().ifValidationFails()
+                .when().log().ifValidationFails()
+                .accept(APPLICATION_JSON_VALUE)
+                .queryParams(queryParams)
+                .get(uri)
                 .then().log().ifError()
                 .extract();
     }

--- a/backend/baton/src/test/java/touch/baton/assure/runner/RunnerProfileAssuredUpdateTest.java
+++ b/backend/baton/src/test/java/touch/baton/assure/runner/RunnerProfileAssuredUpdateTest.java
@@ -1,0 +1,98 @@
+package touch.baton.assure.runner;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import touch.baton.config.AssuredTestConfig;
+import touch.baton.domain.member.Member;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.service.dto.RunnerUpdateRequest;
+import touch.baton.fixture.domain.MemberFixture;
+import touch.baton.fixture.domain.RunnerFixture;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static touch.baton.domain.common.exception.ClientErrorCode.COMPANY_IS_NULL;
+import static touch.baton.domain.common.exception.ClientErrorCode.NAME_IS_NULL;
+import static touch.baton.domain.common.exception.ClientErrorCode.RUNNER_TECHNICAL_TAGS_ARE_NULL;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class RunnerProfileAssuredUpdateTest extends AssuredTestConfig {
+
+    private String 디투_액세스_토큰;
+
+    private Runner 러너_디투;
+
+    @BeforeEach
+    void setUp() {
+        final String 소셜_id = "judySocialId";
+        final Member 사용자_주디 = memberRepository.save(MemberFixture.createWithSocialId(소셜_id));
+        러너_디투 = runnerRepository.save(RunnerFixture.createRunner(사용자_주디));
+        디투_액세스_토큰 = login(소셜_id);
+    }
+
+    @Test
+    void 러너_정보를_수정한다() {
+        final RunnerUpdateRequest 러너_업데이트_요청 = new RunnerUpdateRequest("업데이트된 이름", "업데이트된 소속", "업데이트된 자기소개", List.of("Java", "React"));
+
+        RunnerProfileAssuredSupport
+                .클라이언트_요청()
+                .토큰으로_로그인한다(디투_액세스_토큰)
+                .러너_본인_프로필을_수정한다(러너_업데이트_요청)
+
+                .서버_응답()
+                .러너_본인_프로필_수정_성공을_검증한다(NO_CONTENT, 러너_디투.getId());
+    }
+
+    @Test
+    void 러너_정보_수정_시에_이름이_없으면_예외가_발생한다() {
+        final RunnerUpdateRequest 러너_업데이트_요청 = new RunnerUpdateRequest(null, "업데이트된 소속", "업데이트된 자기소개", List.of("Java", "React"));
+
+        RunnerProfileAssuredSupport
+                .클라이언트_요청()
+                .토큰으로_로그인한다(디투_액세스_토큰)
+                .러너_본인_프로필을_수정한다(러너_업데이트_요청)
+
+                .서버_응답()
+                .러너_본인_프로필_수정_실패를_검증한다(NAME_IS_NULL);
+    }
+
+    @Test
+    void 서포터_정보_수정_시에_소속이_없으면_예외가_발생한다() {
+        final RunnerUpdateRequest 러너_업데이트_요청 = new RunnerUpdateRequest("업데이트된 이름", null, "업데이트된 자기소개", List.of("Java", "React"));
+
+        RunnerProfileAssuredSupport
+                .클라이언트_요청()
+                .토큰으로_로그인한다(디투_액세스_토큰)
+                .러너_본인_프로필을_수정한다(러너_업데이트_요청)
+
+                .서버_응답()
+                .러너_본인_프로필_수정_실패를_검증한다(COMPANY_IS_NULL);
+    }
+
+    @Test
+    void 러너_정보_수정_시에_소개글이_없어도_된다() {
+        final RunnerUpdateRequest 러너_업데이트_요청 = new RunnerUpdateRequest("업데이트된 이름", "업데이트된 소속", null, List.of("Java", "React"));
+
+        RunnerProfileAssuredSupport
+                .클라이언트_요청()
+                .토큰으로_로그인한다(디투_액세스_토큰)
+                .러너_본인_프로필을_수정한다(러너_업데이트_요청)
+
+                .서버_응답()
+                .러너_본인_프로필_수정_성공을_검증한다(NO_CONTENT, 러너_디투.getId());
+    }
+
+    @Test
+    void 러너_정보_수정_시에_기술_태그가_없으면_예외가_발생한다() {
+        final RunnerUpdateRequest 러너_업데이트_요청 = new RunnerUpdateRequest("업데이트된 이름", "업데이트된 소속", "업데이트된 자기소개", null);
+
+        RunnerProfileAssuredSupport
+                .클라이언트_요청()
+                .토큰으로_로그인한다(디투_액세스_토큰)
+                .러너_본인_프로필을_수정한다(러너_업데이트_요청)
+
+                .서버_응답()
+                .러너_본인_프로필_수정_실패를_검증한다(RUNNER_TECHNICAL_TAGS_ARE_NULL);
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostAssuredReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostAssuredReadTest.java
@@ -1,22 +1,35 @@
 package touch.baton.assure.runnerpost;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
 import touch.baton.config.AssuredTestConfig;
+import touch.baton.domain.common.response.PageResponse;
 import touch.baton.domain.member.Member;
 import touch.baton.domain.runner.Runner;
 import touch.baton.domain.runner.controller.response.RunnerResponse;
 import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.controller.response.RunnerPostResponse;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
+import touch.baton.domain.supporter.Supporter;
+import touch.baton.domain.supporter.SupporterRunnerPost;
+import touch.baton.domain.technicaltag.TechnicalTag;
 import touch.baton.fixture.domain.MemberFixture;
 import touch.baton.fixture.domain.RunnerFixture;
 import touch.baton.fixture.domain.RunnerPostFixture;
+import touch.baton.fixture.domain.SupporterFixture;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.List;
 
+import static java.time.LocalDateTime.now;
+import static touch.baton.assure.runnerpost.RunnerPostAssuredSupport.서포터가_리뷰_완료한_러너_게시글_응답;
+import static touch.baton.assure.runnerpost.RunnerPostAssuredSupport.클라이언트_요청;
+import static touch.baton.fixture.domain.TechnicalTagFixture.createJava;
+import static touch.baton.fixture.domain.TechnicalTagFixture.createSpring;
 import static touch.baton.fixture.vo.DeadlineFixture.deadline;
 import static touch.baton.fixture.vo.IntroductionFixture.introduction;
+import static touch.baton.fixture.vo.MessageFixture.message;
+import static touch.baton.fixture.vo.ReviewCountFixture.reviewCount;
 import static touch.baton.fixture.vo.WatchedCountFixture.watchedCount;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -26,11 +39,10 @@ class RunnerPostAssuredReadTest extends AssuredTestConfig {
     void 러너의_게시글_식별자값으로_러너_게시글_상세_정보_조회에_성공한다() {
         final Member 사용자_헤나 = memberRepository.save(MemberFixture.createHyena());
         final Runner 러너_헤나 = runnerRepository.save(RunnerFixture.createRunner(introduction("안녕하세요"), 사용자_헤나));
-        final RunnerPost 러너_게시글 = runnerPostRepository.save(RunnerPostFixture.create(러너_헤나, deadline(LocalDateTime.now().plusHours(100))));
+        final RunnerPost 러너_게시글 = runnerPostRepository.save(RunnerPostFixture.create(러너_헤나, deadline(now().plusHours(100))));
         final String 로그인용_토큰 = login(사용자_헤나.getSocialId().getValue());
 
-        RunnerPostAssuredSupport
-                .클라이언트_요청()
+        클라이언트_요청()
                 .토큰으로_로그인한다(로그인용_토큰)
                 .러너_게시글_식별자값으로_러너_게시글을_조회한다(러너_게시글.getId())
 
@@ -47,5 +59,65 @@ class RunnerPostAssuredReadTest extends AssuredTestConfig {
                         RunnerResponse.Detail.from(러너_헤나),
                         new ArrayList<>()
                 ));
+    }
+
+    @Test
+    void 서포터가_리뷰_완료한_러너_게시글_페이징_조회에_성공한다() {
+        final Runner 러너_에단 = 러너를_저장한다(MemberFixture.createEthan());
+        final Supporter 서포터_헤나 = 서포터_헤나를_저장한다();
+        final RunnerPost 러너_에단의_게시글 = 러너_게시글을_등록한다(러너_에단);
+        러너_게시글에_서포터를_할당한다(서포터_헤나, 러너_에단의_게시글);
+        서포터를_러너_게시글에_저장한다(서포터_헤나, 러너_에단의_게시글);
+
+        final String 헤나_액세스_토큰 = login(서포터_헤나.getMember().getSocialId().getValue());
+
+        final PageRequest 페이징_정보 = PageRequest.of(0, 10);
+        final RunnerPostResponse.ReferencedBySupporter 서포터가_리뷰_완료한_러너_게시글_응답
+                = RunnerPostResponse.ReferencedBySupporter.from(러너_에단의_게시글, 1);
+        final PageResponse<RunnerPostResponse.ReferencedBySupporter> 페이징된_서포터가_리뷰_완료한_러너_게시글_응답
+                = 서포터가_리뷰_완료한_러너_게시글_응답(페이징_정보, List.of(서포터가_리뷰_완료한_러너_게시글_응답));
+
+        RunnerPostAssuredSupport
+                .클라이언트_요청()
+                .토큰으로_로그인한다(헤나_액세스_토큰)
+                .서포터와_연관된_러너_게시글_페이징을_조회한다(서포터_헤나.getId(), ReviewStatus.IN_PROGRESS, 페이징_정보)
+
+                .서버_응답()
+                .서포터와_연관된_러너_게시글_페이징_조회_성공을_검증한다(페이징된_서포터가_리뷰_완료한_러너_게시글_응답);
+    }
+
+    private RunnerPost 러너_게시글에_서포터를_할당한다(final Supporter 서포터_헤나, final RunnerPost 러너_에단의_게시글) {
+        러너_에단의_게시글.assignSupporter(서포터_헤나);
+        return runnerPostRepository.save(러너_에단의_게시글);
+    }
+
+    private RunnerPost 러너_게시글을_등록한다(final Runner 러너) {
+
+        return runnerPostRepository.save(RunnerPostFixture.create(러너, deadline(now().plusHours(100))));
+    }
+
+    private Runner 러너를_저장한다(final Member member) {
+        final Member 저장된_사용자 = memberRepository.save(member);
+
+        return runnerRepository.save(RunnerFixture.createRunner(introduction("안녕하세요"), 저장된_사용자));
+    }
+
+    private Supporter 서포터_헤나를_저장한다() {
+        final TechnicalTag 자바_기술_태그 = technicalTagRepository.save(createJava());
+        final TechnicalTag 스프링_기술_태그 = technicalTagRepository.save(createSpring());
+        final List<TechnicalTag> 기술_태그_목록 = List.of(자바_기술_태그, 스프링_기술_태그);
+        final Member 저장된_사용자_헤나 = memberRepository.save(MemberFixture.createHyena());
+
+        return supporterRepository.save(SupporterFixture.create(reviewCount(0), 저장된_사용자_헤나, 기술_태그_목록));
+    }
+
+    private SupporterRunnerPost 서포터를_러너_게시글에_저장한다(final Supporter 서포터, final RunnerPost 러너_게시글) {
+        final SupporterRunnerPost 서포터_러너_게시글 = SupporterRunnerPost.builder()
+                .runnerPost(러너_게시글)
+                .supporter(서포터)
+                .message(message("안녕하세요. 서포터 헤나입니다."))
+                .build();
+
+        return supporterRunnerPostRepository.save(서포터_러너_게시글);
     }
 }

--- a/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostAssuredSupport.java
+++ b/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostAssuredSupport.java
@@ -1,10 +1,18 @@
 package touch.baton.assure.runnerpost;
 
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import touch.baton.assure.common.AssuredSupport;
+import touch.baton.domain.common.response.PageResponse;
 import touch.baton.domain.runnerpost.controller.response.RunnerPostResponse;
+import touch.baton.domain.runnerpost.vo.ReviewStatus;
+
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -16,6 +24,15 @@ public class RunnerPostAssuredSupport {
 
     public static RunnerPostClientRequestBuilder 클라이언트_요청() {
         return new RunnerPostClientRequestBuilder();
+    }
+
+    public static PageResponse<RunnerPostResponse.ReferencedBySupporter> 서포터가_리뷰_완료한_러너_게시글_응답(final Pageable 페이징_정보,
+                                                                                                     final List<RunnerPostResponse.ReferencedBySupporter> 서포터가_연관된_러너_게시글_목록
+    ) {
+        final PageImpl<RunnerPostResponse.ReferencedBySupporter> 페이징된_서포터가_연관된_러너_게시글 = new PageImpl<>(서포터가_연관된_러너_게시글_목록, 페이징_정보, 1);
+        final PageResponse<RunnerPostResponse.ReferencedBySupporter> 페이징된_서포터가_연관된_러너_게시글_응답 = PageResponse.from(페이징된_서포터가_연관된_러너_게시글);
+
+        return 페이징된_서포터가_연관된_러너_게시글_응답;
     }
 
     public static class RunnerPostClientRequestBuilder {
@@ -31,6 +48,21 @@ public class RunnerPostAssuredSupport {
 
         public RunnerPostClientRequestBuilder 러너_게시글_식별자값으로_러너_게시글을_조회한다(final Long 러너_게시글_식별자값) {
             response = AssuredSupport.get("/api/v1/posts/runner/{runnerPostId}", "runnerPostId", 러너_게시글_식별자값, accessToken);
+            return this;
+        }
+
+        public RunnerPostClientRequestBuilder 서포터와_연관된_러너_게시글_페이징을_조회한다(final Long 서포터_식별자값,
+                                                                        final ReviewStatus 리뷰_상태,
+                                                                        final Pageable 페이징_정보
+        ) {
+            final Map<String, Object> queryParams = Map.of(
+                    "supporterId", 서포터_식별자값,
+                    "reviewStatus", 리뷰_상태,
+                    "size", 페이징_정보.getPageSize(),
+                    "page", 페이징_정보.getPageNumber()
+            );
+
+            response = AssuredSupport.get("/api/v1/posts/runner/search", queryParams);
             return this;
         }
 
@@ -66,6 +98,23 @@ public class RunnerPostAssuredSupport {
                         softly.assertThat(actual.runnerProfile().runnerId()).isEqualTo(러너_게시글_응답.runnerProfile().runnerId());
                         softly.assertThat(actual.watchedCount()).isEqualTo(러너_게시글_응답.watchedCount());
                         softly.assertThat(actual.runnerPostId()).isEqualTo(러너_게시글_응답.runnerPostId());
+                    }
+            );
+        }
+
+        public void 서포터와_연관된_러너_게시글_페이징_조회_성공을_검증한다(final PageResponse<RunnerPostResponse.ReferencedBySupporter> 서포터와_연관된_러너_게시글_페이징_응답) {
+            final PageResponse<RunnerPostResponse.ReferencedBySupporter> actual = this.response.as(new TypeRef<PageResponse<RunnerPostResponse.ReferencedBySupporter>>() {
+            });
+
+            assertSoftly(softly -> {
+                        softly.assertThat(actual.data()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.data());
+                        softly.assertThat(actual.pageInfo().isFirst()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().isFirst());
+                        softly.assertThat(actual.pageInfo().isLast()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().isLast());
+                        softly.assertThat(actual.pageInfo().hasNext()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().hasNext());
+                        softly.assertThat(actual.pageInfo().totalPages()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().totalPages());
+                        softly.assertThat(actual.pageInfo().totalElements()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().totalElements());
+                        softly.assertThat(actual.pageInfo().currentPage()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().currentPage());
+                        softly.assertThat(actual.pageInfo().currentSize()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().currentSize());
                     }
             );
         }

--- a/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostAssuredSupport.java
+++ b/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostAssuredSupport.java
@@ -30,7 +30,7 @@ public class RunnerPostAssuredSupport {
     public static PageResponse<RunnerPostResponse.ReferencedBySupporter> 서포터가_리뷰_완료한_러너_게시글_응답(final Pageable 페이징_정보,
                                                                                                final List<RunnerPostResponse.ReferencedBySupporter> 서포터가_연관된_러너_게시글_목록
     ) {
-        final Page<RunnerPostResponse.ReferencedBySupporter> 페이징된_서포터가_연관된_러너_게시글 = new PageImpl<>(서포터가_연관된_러너_게시글_목록, 페이징_정보, 1);
+        final Page<RunnerPostResponse.ReferencedBySupporter> 페이징된_서포터가_연관된_러너_게시글 = new PageImpl<>(서포터가_연관된_러너_게시글_목록, 페이징_정보, 서포터가_연관된_러너_게시글_목록.size());
         final PageResponse<RunnerPostResponse.ReferencedBySupporter> 페이징된_서포터가_연관된_러너_게시글_응답 = PageResponse.from(페이징된_서포터가_연관된_러너_게시글);
 
         return 페이징된_서포터가_연관된_러너_게시글_응답;
@@ -110,13 +110,6 @@ public class RunnerPostAssuredSupport {
             assertSoftly(softly -> {
                         softly.assertThat(this.response.statusCode()).isEqualTo(HttpStatus.OK.value());
                         softly.assertThat(actual.data()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.data());
-                        softly.assertThat(actual.pageInfo().isFirst()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().isFirst());
-                        softly.assertThat(actual.pageInfo().isLast()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().isLast());
-                        softly.assertThat(actual.pageInfo().hasNext()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().hasNext());
-                        softly.assertThat(actual.pageInfo().totalPages()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().totalPages());
-                        softly.assertThat(actual.pageInfo().totalElements()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().totalElements());
-                        softly.assertThat(actual.pageInfo().currentPage()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().currentPage());
-                        softly.assertThat(actual.pageInfo().currentSize()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().currentSize());
                     }
             );
         }

--- a/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostAssuredSupport.java
+++ b/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostAssuredSupport.java
@@ -3,6 +3,7 @@ package touch.baton.assure.runnerpost;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -27,9 +28,9 @@ public class RunnerPostAssuredSupport {
     }
 
     public static PageResponse<RunnerPostResponse.ReferencedBySupporter> 서포터가_리뷰_완료한_러너_게시글_응답(final Pageable 페이징_정보,
-                                                                                                     final List<RunnerPostResponse.ReferencedBySupporter> 서포터가_연관된_러너_게시글_목록
+                                                                                               final List<RunnerPostResponse.ReferencedBySupporter> 서포터가_연관된_러너_게시글_목록
     ) {
-        final PageImpl<RunnerPostResponse.ReferencedBySupporter> 페이징된_서포터가_연관된_러너_게시글 = new PageImpl<>(서포터가_연관된_러너_게시글_목록, 페이징_정보, 1);
+        final Page<RunnerPostResponse.ReferencedBySupporter> 페이징된_서포터가_연관된_러너_게시글 = new PageImpl<>(서포터가_연관된_러너_게시글_목록, 페이징_정보, 1);
         final PageResponse<RunnerPostResponse.ReferencedBySupporter> 페이징된_서포터가_연관된_러너_게시글_응답 = PageResponse.from(페이징된_서포터가_연관된_러너_게시글);
 
         return 페이징된_서포터가_연관된_러너_게시글_응답;
@@ -107,6 +108,7 @@ public class RunnerPostAssuredSupport {
             });
 
             assertSoftly(softly -> {
+                        softly.assertThat(this.response.statusCode()).isEqualTo(HttpStatus.OK.value());
                         softly.assertThat(actual.data()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.data());
                         softly.assertThat(actual.pageInfo().isFirst()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().isFirst());
                         softly.assertThat(actual.pageInfo().isLast()).isEqualTo(서포터와_연관된_러너_게시글_페이징_응답.pageInfo().isLast());

--- a/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostReadWithGuestAssuredTest.java
+++ b/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostReadWithGuestAssuredTest.java
@@ -38,18 +38,22 @@ class RunnerPostReadWithGuestAssuredTest extends AssuredTestConfig {
         러너_게시글에_서포터를_할당한다(서포터_헤나, 러너_에단의_게시글);
         서포터를_러너_게시글에_저장한다(서포터_헤나, 러너_에단의_게시글);
 
+        // FIXME: 2023/08/13 러너 게시글 리뷰 완료 요청 기능 구현시 아래 ReviewStatus.DONE 테스트를 수정해야한다.
+        러너_에단의_게시글.updateReviewStatus(ReviewStatus.DONE);
+        runnerPostRepository.save(러너_에단의_게시글);
+
         final String 헤나_액세스_토큰 = login(서포터_헤나.getMember().getSocialId().getValue());
 
-        final PageRequest 페이징_정보 = PageRequest.of(0, 10);
+        final PageRequest 페이징_정보 = PageRequest.of(1, 10);
         final RunnerPostResponse.ReferencedBySupporter 서포터가_리뷰_완료한_러너_게시글_응답
-                = RunnerPostResponse.ReferencedBySupporter.from(러너_에단의_게시글, 1);
+                = RunnerPostResponse.ReferencedBySupporter.of(러너_에단의_게시글, 1);
         final PageResponse<RunnerPostResponse.ReferencedBySupporter> 페이징된_서포터가_리뷰_완료한_러너_게시글_응답
                 = 서포터가_리뷰_완료한_러너_게시글_응답(페이징_정보, List.of(서포터가_리뷰_완료한_러너_게시글_응답));
 
         RunnerPostAssuredSupport
                 .클라이언트_요청()
                 .토큰으로_로그인한다(헤나_액세스_토큰)
-                .서포터와_연관된_러너_게시글_페이징을_조회한다(서포터_헤나.getId(), ReviewStatus.IN_PROGRESS, 페이징_정보)
+                .서포터와_연관된_러너_게시글_페이징을_조회한다(서포터_헤나.getId(), ReviewStatus.DONE, 페이징_정보)
 
                 .서버_응답()
                 .서포터와_연관된_러너_게시글_페이징_조회_성공을_검증한다(페이징된_서포터가_리뷰_완료한_러너_게시글_응답);

--- a/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostReadWithGuestAssuredTest.java
+++ b/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostReadWithGuestAssuredTest.java
@@ -6,7 +6,6 @@ import touch.baton.config.AssuredTestConfig;
 import touch.baton.domain.common.response.PageResponse;
 import touch.baton.domain.member.Member;
 import touch.baton.domain.runner.Runner;
-import touch.baton.domain.runner.controller.response.RunnerResponse;
 import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.controller.response.RunnerPostResponse;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
@@ -18,48 +17,18 @@ import touch.baton.fixture.domain.RunnerFixture;
 import touch.baton.fixture.domain.RunnerPostFixture;
 import touch.baton.fixture.domain.SupporterFixture;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static java.time.LocalDateTime.now;
 import static touch.baton.assure.runnerpost.RunnerPostAssuredSupport.서포터가_리뷰_완료한_러너_게시글_응답;
-import static touch.baton.assure.runnerpost.RunnerPostAssuredSupport.클라이언트_요청;
 import static touch.baton.fixture.domain.TechnicalTagFixture.createJava;
 import static touch.baton.fixture.domain.TechnicalTagFixture.createSpring;
 import static touch.baton.fixture.vo.DeadlineFixture.deadline;
 import static touch.baton.fixture.vo.IntroductionFixture.introduction;
 import static touch.baton.fixture.vo.MessageFixture.message;
 import static touch.baton.fixture.vo.ReviewCountFixture.reviewCount;
-import static touch.baton.fixture.vo.WatchedCountFixture.watchedCount;
 
-@SuppressWarnings("NonAsciiCharacters")
-class RunnerPostAssuredReadTest extends AssuredTestConfig {
-
-    @Test
-    void 러너의_게시글_식별자값으로_러너_게시글_상세_정보_조회에_성공한다() {
-        final Member 사용자_헤나 = memberRepository.save(MemberFixture.createHyena());
-        final Runner 러너_헤나 = runnerRepository.save(RunnerFixture.createRunner(introduction("안녕하세요"), 사용자_헤나));
-        final RunnerPost 러너_게시글 = runnerPostRepository.save(RunnerPostFixture.create(러너_헤나, deadline(now().plusHours(100))));
-        final String 로그인용_토큰 = login(사용자_헤나.getSocialId().getValue());
-
-        클라이언트_요청()
-                .토큰으로_로그인한다(로그인용_토큰)
-                .러너_게시글_식별자값으로_러너_게시글을_조회한다(러너_게시글.getId())
-
-                .서버_응답()
-                .러너_게시글_단건_조회_성공을_검증한다(new RunnerPostResponse.Detail(
-                        러너_게시글.getId(),
-                        러너_게시글.getTitle().getValue(),
-                        러너_게시글.getContents().getValue(),
-                        러너_게시글.getPullRequestUrl().getValue(),
-                        러너_게시글.getDeadline().getValue(),
-                        watchedCount(1).getValue(),
-                        ReviewStatus.NOT_STARTED,
-                        true,
-                        RunnerResponse.Detail.from(러너_헤나),
-                        new ArrayList<>()
-                ));
-    }
+class RunnerPostReadWithGuestAssuredTest extends AssuredTestConfig {
 
     @Test
     void 서포터가_리뷰_완료한_러너_게시글_페이징_조회에_성공한다() {

--- a/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostReadWithLoginedAssuredTest.java
+++ b/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostReadWithLoginedAssuredTest.java
@@ -1,0 +1,51 @@
+ package touch.baton.assure.runnerpost;
+
+import org.junit.jupiter.api.Test;
+import touch.baton.config.AssuredTestConfig;
+import touch.baton.domain.member.Member;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.controller.response.RunnerResponse;
+import touch.baton.domain.runnerpost.RunnerPost;
+import touch.baton.domain.runnerpost.controller.response.RunnerPostResponse;
+import touch.baton.domain.runnerpost.vo.ReviewStatus;
+import touch.baton.fixture.domain.MemberFixture;
+import touch.baton.fixture.domain.RunnerFixture;
+import touch.baton.fixture.domain.RunnerPostFixture;
+
+import java.util.ArrayList;
+
+import static java.time.LocalDateTime.now;
+import static touch.baton.assure.runnerpost.RunnerPostAssuredSupport.클라이언트_요청;
+import static touch.baton.fixture.vo.DeadlineFixture.deadline;
+import static touch.baton.fixture.vo.IntroductionFixture.introduction;
+import static touch.baton.fixture.vo.WatchedCountFixture.watchedCount;
+
+@SuppressWarnings("NonAsciiCharacters")
+class RunnerPostReadWithLoginedAssuredTest extends AssuredTestConfig {
+
+    @Test
+    void 러너의_게시글_식별자값으로_러너_게시글_상세_정보_조회에_성공한다() {
+        final Member 사용자_헤나 = memberRepository.save(MemberFixture.createHyena());
+        final Runner 러너_헤나 = runnerRepository.save(RunnerFixture.createRunner(introduction("안녕하세요"), 사용자_헤나));
+        final RunnerPost 러너_게시글 = runnerPostRepository.save(RunnerPostFixture.create(러너_헤나, deadline(now().plusHours(100))));
+        final String 로그인용_토큰 = login(사용자_헤나.getSocialId().getValue());
+
+        클라이언트_요청()
+                .토큰으로_로그인한다(로그인용_토큰)
+                .러너_게시글_식별자값으로_러너_게시글을_조회한다(러너_게시글.getId())
+
+                .서버_응답()
+                .러너_게시글_단건_조회_성공을_검증한다(new RunnerPostResponse.Detail(
+                        러너_게시글.getId(),
+                        러너_게시글.getTitle().getValue(),
+                        러너_게시글.getContents().getValue(),
+                        러너_게시글.getPullRequestUrl().getValue(),
+                        러너_게시글.getDeadline().getValue(),
+                        watchedCount(1).getValue(),
+                        ReviewStatus.NOT_STARTED,
+                        true,
+                        RunnerResponse.Detail.from(러너_헤나),
+                        new ArrayList<>()
+                ));
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/assure/supporter/SupporterProfileAssuredSupport.java
+++ b/backend/baton/src/test/java/touch/baton/assure/supporter/SupporterProfileAssuredSupport.java
@@ -80,7 +80,6 @@ public class SupporterProfileAssuredSupport {
                 softly.assertThat(response.statusCode()).isEqualTo(HTTP_STATUS.value());
                 softly.assertThat(response.header("Location")).isNotNull();
             });
-
         }
 
         public void 서포터_본인_프로필_수정_실패를_검증한다(final ClientErrorCode clientErrorCode) {

--- a/backend/baton/src/test/java/touch/baton/config/AssuredTestConfig.java
+++ b/backend/baton/src/test/java/touch/baton/config/AssuredTestConfig.java
@@ -12,18 +12,20 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestExecutionListeners;
+import touch.baton.config.converter.ConverterConfig;
 import touch.baton.domain.member.repository.MemberRepository;
 import touch.baton.domain.runner.repository.RunnerRepository;
 import touch.baton.domain.runnerpost.repository.RunnerPostRepository;
 import touch.baton.domain.supporter.repository.SupporterRepository;
 import touch.baton.domain.technicaltag.repository.TechnicalTagRepository;
+import touch.baton.domain.supporter.repository.SupporterRunnerPostRepository;
 import touch.baton.infra.auth.jwt.JwtDecoder;
 
 import java.util.UUID;
 
 import static org.mockito.BDDMockito.when;
 
-@Import(JpaConfig.class)
+@Import({JpaConfig.class, ConverterConfig.class})
 @TestExecutionListeners(value = AssuredTestExecutionListener.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -40,6 +42,9 @@ public abstract class AssuredTestConfig {
 
     @Autowired
     protected SupporterRepository supporterRepository;
+
+    @Autowired
+    protected SupporterRunnerPostRepository supporterRunnerPostRepository;
 
     @MockBean
     private JwtDecoder jwtDecoder;

--- a/backend/baton/src/test/java/touch/baton/config/AssuredTestConfig.java
+++ b/backend/baton/src/test/java/touch/baton/config/AssuredTestConfig.java
@@ -17,15 +17,15 @@ import touch.baton.domain.member.repository.MemberRepository;
 import touch.baton.domain.runner.repository.RunnerRepository;
 import touch.baton.domain.runnerpost.repository.RunnerPostRepository;
 import touch.baton.domain.supporter.repository.SupporterRepository;
-import touch.baton.domain.technicaltag.repository.TechnicalTagRepository;
 import touch.baton.domain.supporter.repository.SupporterRunnerPostRepository;
+import touch.baton.domain.technicaltag.repository.TechnicalTagRepository;
 import touch.baton.infra.auth.jwt.JwtDecoder;
 
 import java.util.UUID;
 
 import static org.mockito.BDDMockito.when;
 
-@Import({JpaConfig.class, ConverterConfig.class})
+@Import({JpaConfig.class, ConverterConfig.class, PageableTestConfig.class})
 @TestExecutionListeners(value = AssuredTestExecutionListener.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)

--- a/backend/baton/src/test/java/touch/baton/config/PageableTestConfig.java
+++ b/backend/baton/src/test/java/touch/baton/config/PageableTestConfig.java
@@ -1,0 +1,14 @@
+package touch.baton.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.web.config.PageableHandlerMethodArgumentResolverCustomizer;
+
+@TestConfiguration
+public abstract class PageableTestConfig {
+
+    @Bean
+    public PageableHandlerMethodArgumentResolverCustomizer pageableResolverCustomizer() {
+        return pageableResolver -> pageableResolver.setOneIndexedParameters(true);
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/config/RestdocsConfig.java
+++ b/backend/baton/src/test/java/touch/baton/config/RestdocsConfig.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.format.support.FormattingConversionService;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -21,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import touch.baton.config.converter.ConverterConfig;
 import touch.baton.config.converter.OauthTypeConverter;
+import touch.baton.config.converter.ReviewStatusConverter;
 import touch.baton.domain.oauth.controller.resolver.AuthMemberPrincipalArgumentResolver;
 import touch.baton.domain.oauth.controller.resolver.AuthRunnerPrincipalArgumentResolver;
 import touch.baton.domain.oauth.controller.resolver.AuthSupporterPrincipalArgumentResolver;
@@ -34,9 +36,7 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 
 @ExtendWith(RestDocumentationExtension.class)
 @Import({RestDocsResultConfig.class, ConverterConfig.class})
@@ -81,9 +81,14 @@ public abstract class RestdocsConfig {
 
         final FormattingConversionService formattingConversionService = new FormattingConversionService();
         formattingConversionService.addConverter(new OauthTypeConverter());
+        formattingConversionService.addConverter(new ReviewStatusConverter());
 
         this.mockMvc = MockMvcBuilders.standaloneSetup(controller)
-                .setCustomArgumentResolvers(authMemberPrincipalArgumentResolver, authRunnerPrincipalArgumentResolver, authSupporterPrincipalArgumentResolver)
+                .setCustomArgumentResolvers(
+                        authMemberPrincipalArgumentResolver,
+                        authRunnerPrincipalArgumentResolver,
+                        authSupporterPrincipalArgumentResolver,
+                        new PageableHandlerMethodArgumentResolver())
                 .apply(documentationConfiguration(restDocumentation))
                 .setConversionService(formattingConversionService)
                 .setMessageConverters(jackson2HttpMessageConverter)

--- a/backend/baton/src/test/java/touch/baton/config/ServiceTestConfig.java
+++ b/backend/baton/src/test/java/touch/baton/config/ServiceTestConfig.java
@@ -6,6 +6,7 @@ import touch.baton.domain.member.repository.MemberRepository;
 import touch.baton.domain.runner.repository.RunnerRepository;
 import touch.baton.domain.runnerpost.repository.RunnerPostRepository;
 import touch.baton.domain.supporter.repository.SupporterRepository;
+import touch.baton.domain.supporter.repository.SupporterRunnerPostRepository;
 import touch.baton.domain.tag.repository.RunnerPostTagRepository;
 import touch.baton.domain.technicaltag.repository.RunnerTechnicalTagRepository;
 import touch.baton.domain.tag.repository.TagRepository;
@@ -43,4 +44,7 @@ public abstract class ServiceTestConfig extends RepositoryTestConfig {
 
     @Autowired
     protected SupporterTechnicalTagRepository supporterTechnicalTagRepository;
+
+    @Autowired
+    protected SupporterRunnerPostRepository supporterRunnerPostRepository;
 }

--- a/backend/baton/src/test/java/touch/baton/config/ServiceTestConfig.java
+++ b/backend/baton/src/test/java/touch/baton/config/ServiceTestConfig.java
@@ -7,6 +7,7 @@ import touch.baton.domain.runner.repository.RunnerRepository;
 import touch.baton.domain.runnerpost.repository.RunnerPostRepository;
 import touch.baton.domain.supporter.repository.SupporterRepository;
 import touch.baton.domain.tag.repository.RunnerPostTagRepository;
+import touch.baton.domain.technicaltag.repository.RunnerTechnicalTagRepository;
 import touch.baton.domain.tag.repository.TagRepository;
 import touch.baton.domain.technicaltag.repository.SupporterTechnicalTagRepository;
 import touch.baton.domain.technicaltag.repository.TechnicalTagRepository;
@@ -36,6 +37,9 @@ public abstract class ServiceTestConfig extends RepositoryTestConfig {
 
     @Autowired
     protected TechnicalTagRepository technicalTagRepository;
+
+    @Autowired
+    protected RunnerTechnicalTagRepository runnerTechnicalTagRepository;
 
     @Autowired
     protected SupporterTechnicalTagRepository supporterTechnicalTagRepository;

--- a/backend/baton/src/test/java/touch/baton/document/profile/runner/read/RunnerProfileReadApiTest.java
+++ b/backend/baton/src/test/java/touch/baton/document/profile/runner/read/RunnerProfileReadApiTest.java
@@ -1,4 +1,3 @@
-
 package touch.baton.document.profile.runner.read;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -97,7 +96,7 @@ class RunnerProfileReadApiTest extends RestdocsConfig {
 
         // when
         when(spyRunner.getId()).thenReturn(1L);
-        when(runnerService.readRunnerById(anyLong())).thenReturn(spyRunner);
+        when(runnerService.readByRunnerId(anyLong())).thenReturn(spyRunner);
 
         // then
         mockMvc.perform(get("/api/v1/profile/runner/{runnerId}", 1L))
@@ -115,4 +114,20 @@ class RunnerProfileReadApiTest extends RestdocsConfig {
                         )
                 ));
     }
+
+    //    @DisplayName("러너 프로필 조회 API")
+//    @Test
+//    void read() throws Exception {
+//        // TODO: 로그인 들어오면 작성하겠삼.
+//        // given
+//        final Runner runner = RunnerFixture.createRunner(MemberFixture.createHyena());
+//        final Deadline deadline = deadline(LocalDateTime.now().plusHours(100));
+//        final Tag javaTag = TagFixture.create(tagName("자바"), tagCount(10));
+//        final RunnerPost runnerPost = RunnerPostFixture.create(runner, deadline, List.of(javaTag));
+//        final RunnerPost spyRunnerPost = spy(runnerPost);
+//
+//        // when
+//
+//        // then
+//    }
 }

--- a/backend/baton/src/test/java/touch/baton/document/profile/runner/update/RunnerProfileUpdateApiTest.java
+++ b/backend/baton/src/test/java/touch/baton/document/profile/runner/update/RunnerProfileUpdateApiTest.java
@@ -1,0 +1,92 @@
+package touch.baton.document.profile.runner.update;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import touch.baton.config.RestdocsConfig;
+import touch.baton.domain.member.Member;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.controller.RunnerProfileController;
+import touch.baton.domain.runner.service.RunnerService;
+import touch.baton.domain.runner.service.dto.RunnerUpdateRequest;
+import touch.baton.domain.runnerpost.service.RunnerPostService;
+import touch.baton.domain.supporter.controller.SupporterProfileController;
+import touch.baton.fixture.domain.MemberFixture;
+import touch.baton.fixture.domain.RunnerFixture;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpHeaders.LOCATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RunnerProfileController.class)
+public class RunnerProfileUpdateApiTest extends RestdocsConfig {
+
+    @MockBean
+    private RunnerService runnerService;
+
+    @MockBean
+    private RunnerPostService runnerPostService;
+
+    @BeforeEach
+    void setUp() {
+        final RunnerProfileController runnerProfileController = new RunnerProfileController(runnerPostService, runnerService);
+        restdocsSetUp(runnerProfileController);
+    }
+
+    @DisplayName("러너 프로필 수정 API")
+    @Test
+    void updateRunnerProfile() throws Exception {
+        // given
+        final RunnerUpdateRequest request = new RunnerUpdateRequest("주디", "우아한테크코스", "주디입니다.", List.of("spring", "java"));
+        final String requestBody = objectMapper.writeValueAsString(request);
+        final String socialId = "judySocicalId";
+        final Member judyMember = MemberFixture.createJudy();
+        final Runner judyRunner = RunnerFixture.createRunner(judyMember);
+        final String token = getAccessTokenBySocialId(socialId);
+
+        // when
+        when(oauthRunnerRepository.joinByMemberSocialId(any()))
+                .thenReturn(Optional.ofNullable(judyRunner));
+
+        // then
+        mockMvc.perform(patch("/api/v1/profile/runner/me")
+                        .header(AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(requestBody))
+                .andExpect(status().isNoContent())
+                .andExpect(header().string("Location", "/api/v1/profile/runner/me"))
+                .andDo(restDocs.document(
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION).description("Bearer JWT"),
+                                headerWithName(CONTENT_TYPE).description("application/json")
+                        ),
+                        requestFields(
+                                fieldWithPath("name").type(STRING).description("변경할 이름"),
+                                fieldWithPath("company").type(STRING).description("변경할 소속"),
+                                fieldWithPath("introduction").type(STRING).description("변경할 소개글"),
+                                fieldWithPath("technicalTags.[]").type(ARRAY).description("변경할 기술 태그 목록")
+                        ),
+                        responseHeaders(headerWithName(LOCATION).description("redirect uri"))
+                ))
+                .andDo(print());
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/document/runnerpost/read/RunnerPostReadApiTest.java
+++ b/backend/baton/src/test/java/touch/baton/document/runnerpost/read/RunnerPostReadApiTest.java
@@ -109,8 +109,8 @@ class RunnerPostReadApiTest extends RestdocsConfig {
         when(spyRunnerPost.getId()).thenReturn(1L);
 
         final List<RunnerPost> runnerPosts = List.of(spyRunnerPost);
-        final PageRequest pageable = PageRequest.of(10, 10);
-        final PageImpl<RunnerPost> pageRunnerPosts = new PageImpl<>(runnerPosts, pageable, runnerPosts.size());
+        final PageRequest pageOne = PageRequest.of(1, 10);
+        final PageImpl<RunnerPost> pageRunnerPosts = new PageImpl<>(runnerPosts, pageOne, runnerPosts.size());
         when(runnerPostService.readRunnerPostsBySupporterIdAndReviewStatus(any(), any(), any()))
                 .thenReturn(pageRunnerPosts);
         when(runnerPostService.readCountsByRunnerPostIds(anyList()))
@@ -120,8 +120,8 @@ class RunnerPostReadApiTest extends RestdocsConfig {
         mockMvc.perform(get("/api/v1/posts/runner/search")
                         .characterEncoding(UTF_8)
                         .accept(APPLICATION_JSON)
-                        .queryParam("size", String.valueOf(pageable.getPageSize()))
-                        .queryParam("page", String.valueOf(pageable.getPageNumber()))
+                        .queryParam("size", String.valueOf(pageOne.getPageSize()))
+                        .queryParam("page", String.valueOf(pageOne.getPageNumber()))
                         .queryParam("supporterId", String.valueOf(spySupporterHyena.getId()))
                         .queryParam("reviewStatus", ReviewStatus.IN_PROGRESS.name()))
                 .andExpect(status().isOk())

--- a/backend/baton/src/test/java/touch/baton/document/runnerpost/read/RunnerPostReadApiTest.java
+++ b/backend/baton/src/test/java/touch/baton/document/runnerpost/read/RunnerPostReadApiTest.java
@@ -5,33 +5,45 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import touch.baton.config.RestdocsConfig;
 import touch.baton.domain.runner.Runner;
 import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.controller.RunnerPostController;
 import touch.baton.domain.runnerpost.service.RunnerPostService;
 import touch.baton.domain.runnerpost.vo.Deadline;
+import touch.baton.domain.runnerpost.vo.ReviewStatus;
+import touch.baton.domain.supporter.Supporter;
 import touch.baton.domain.tag.Tag;
 import touch.baton.fixture.domain.MemberFixture;
 import touch.baton.fixture.domain.RunnerFixture;
 import touch.baton.fixture.domain.RunnerPostFixture;
+import touch.baton.fixture.domain.SupporterFixture;
 import touch.baton.fixture.domain.TagFixture;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.when;
 import static org.mockito.Mockito.spy;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
-import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
-import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static touch.baton.fixture.domain.TechnicalTagFixture.createJava;
+import static touch.baton.fixture.domain.TechnicalTagFixture.createSpring;
 import static touch.baton.fixture.vo.DeadlineFixture.deadline;
+import static touch.baton.fixture.vo.ReviewCountFixture.reviewCount;
 import static touch.baton.fixture.vo.TagNameFixture.tagName;
 
 @WebMvcTest(RunnerPostController.class)
@@ -74,6 +86,68 @@ class RunnerPostReadApiTest extends RestdocsConfig {
                                 fieldWithPath("data.[].runnerProfile.name").type(STRING).description("러너 게시글의 러너 프로필 이름"),
                                 fieldWithPath("data.[].runnerProfile.imageUrl").type(STRING).description("러너 게시글의 러너 프로필 이미지"),
                                 fieldWithPath("data.[].tags.[]").type(ARRAY).description("러너 게시글의 태그 목록")
+                        ))
+                );
+    }
+
+    @DisplayName("서포터와 연관된 러너 게시글 페이징 조회 API")
+    @Test
+    void readReferencedBySupporter() throws Exception {
+        // given
+        final Runner runnerJudy = RunnerFixture.createRunner(MemberFixture.createJudy());
+        final Supporter supporterHyena = SupporterFixture.create(reviewCount(10), MemberFixture.createHyena(), List.of(createJava(), createSpring()));
+
+        final Tag javaTag = TagFixture.create(tagName("자바"));
+        final Deadline deadline = deadline(LocalDateTime.now().plusHours(100));
+        final RunnerPost runnerPost = RunnerPostFixture.create(runnerJudy, deadline, List.of(javaTag));
+        runnerPost.assignSupporter(supporterHyena);
+
+        // when
+        final RunnerPost spyRunnerPost = spy(runnerPost);
+        final Supporter spySupporterHyena = spy(supporterHyena);
+        when(spySupporterHyena.getId()).thenReturn(1L);
+        when(spyRunnerPost.getId()).thenReturn(1L);
+
+        final List<RunnerPost> runnerPosts = List.of(spyRunnerPost);
+        final PageRequest pageable = PageRequest.of(10, 10);
+        final PageImpl<RunnerPost> pageRunnerPosts = new PageImpl<>(runnerPosts, pageable, runnerPosts.size());
+        when(runnerPostService.readRunnerPostsBySupporterIdAndReviewStatus(any(), any(), any()))
+                .thenReturn(pageRunnerPosts);
+        when(runnerPostService.readCountsByRunnerPostIds(anyList()))
+                .thenReturn(List.of(1));
+
+        // then
+        mockMvc.perform(get("/api/v1/posts/runner/search")
+                        .characterEncoding(UTF_8)
+                        .accept(APPLICATION_JSON)
+                        .queryParam("size", String.valueOf(pageable.getPageSize()))
+                        .queryParam("page", String.valueOf(pageable.getPageNumber()))
+                        .queryParam("supporterId", String.valueOf(spySupporterHyena.getId()))
+                        .queryParam("reviewStatus", ReviewStatus.IN_PROGRESS.name()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(APPLICATION_JSON))
+                .andDo(restDocs.document(
+                        queryParameters(
+                                parameterWithName("size").description("페이지 사이즈"),
+                                parameterWithName("page").description("페이지 번호"),
+                                parameterWithName("supporterId").description("서포터 식별자값"),
+                                parameterWithName("reviewStatus").description("리뷰 상태")
+                        ),
+                        responseFields(
+                                fieldWithPath("pageInfo.isFirst").type(BOOLEAN).description("첫 번째 페이지인지"),
+                                fieldWithPath("pageInfo.isLast").type(BOOLEAN).description("마지막 페이지 인지"),
+                                fieldWithPath("pageInfo.hasNext").type(BOOLEAN).description("다음 페이지가 있는지"),
+                                fieldWithPath("pageInfo.totalPages").type(NUMBER).description("총 페이지 수"),
+                                fieldWithPath("pageInfo.totalElements").type(NUMBER).description("총 데이터 수"),
+                                fieldWithPath("pageInfo.currentPage").type(NUMBER).description("현재 페이지 번호"),
+                                fieldWithPath("pageInfo.currentSize").type(NUMBER).description("현재 페이지 데이터 수"),
+                                fieldWithPath("data.[].runnerPostId").type(NUMBER).description("러너 게시글 식별자값(id)"),
+                                fieldWithPath("data.[].title").type(STRING).description("러너 게시글 제목"),
+                                fieldWithPath("data.[].deadline").type(STRING).description("러너 게시글의 마감 기한"),
+                                fieldWithPath("data.[].tags").type(ARRAY).description("러너 게시글 태그 목록"),
+                                fieldWithPath("data.[].watchedCount").type(NUMBER).description("러너 게시글의 조회수"),
+                                fieldWithPath("data.[].applicantCount").type(NUMBER).description("러너 게시글에 신청한 서포터 수"),
+                                fieldWithPath("data.[].reviewStatus").type(STRING).description("러너 게시글 리뷰 상태")
                         ))
                 );
     }

--- a/backend/baton/src/test/java/touch/baton/domain/runner/service/RunnerServiceReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runner/service/RunnerServiceReadTest.java
@@ -22,7 +22,7 @@ class RunnerServiceReadTest extends ServiceTestConfig {
 
     @BeforeEach
     void setUp() {
-        runnerService = new RunnerService(runnerRepository);
+        runnerService = new RunnerService(runnerRepository, runnerTechnicalTagRepository, technicalTagRepository);
     }
 
     @DisplayName("러너를 사용자와 함께 조회한다.")
@@ -37,7 +37,7 @@ class RunnerServiceReadTest extends ServiceTestConfig {
         final Runner expectedRunner = runnerRepository.save(RunnerFixture.createRunner(expectedMember, technicalTags));
 
         // when
-        final Runner actualRunner = runnerService.readRunnerById(expectedRunner.getId());
+        final Runner actualRunner = runnerService.readByRunnerId(expectedRunner.getId());
 
         // then
         final Member actualMember = actualRunner.getMember();

--- a/backend/baton/src/test/java/touch/baton/domain/runner/service/RunnerServiceUpdateTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runner/service/RunnerServiceUpdateTest.java
@@ -1,0 +1,69 @@
+package touch.baton.domain.runner.service;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import touch.baton.config.ServiceTestConfig;
+import touch.baton.domain.common.vo.TagName;
+import touch.baton.domain.member.Member;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.service.dto.RunnerUpdateRequest;
+import touch.baton.fixture.domain.MemberFixture;
+import touch.baton.fixture.domain.RunnerFixture;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class RunnerServiceUpdateTest extends ServiceTestConfig {
+
+    private RunnerService runnerService;
+
+    @BeforeEach
+    void setUp() {
+        runnerService = new RunnerService(runnerRepository, runnerTechnicalTagRepository, technicalTagRepository);
+    }
+
+    @DisplayName("Runner 의 프로필을 수정한다.")
+    @Test
+    void updateRunnerProfile() {
+        // given
+        final Member memberJudy = memberRepository.save(MemberFixture.createJudy());
+        final Runner runnerJudy = runnerRepository.save(RunnerFixture.createRunner(memberJudy));
+        final RunnerUpdateRequest runnerUpdateRequest = new RunnerUpdateRequest("변경된 이름", "변경된 회사", "변경된 자기소개", List.of("changedTag1", "changedTag2"));
+
+        // when, then
+        assertThatCode(() -> runnerService.updateRunner(runnerJudy, runnerUpdateRequest))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("수정된 Runner 의 프로필을 조회하고 검증한다.")
+    @Test
+    void readUpdatedRunnerProfile() {
+        // given
+        final Member memberJudy = memberRepository.save(MemberFixture.createJudy());
+        final Runner runnerJudy = runnerRepository.save(RunnerFixture.createRunner(memberJudy));
+        final RunnerUpdateRequest runnerUpdateRequest = new RunnerUpdateRequest("변경된 이름", "변경된 회사", "변경된 자기소개", List.of("changedTag1", "changedTag2"));
+
+        runnerService.updateRunner(runnerJudy, runnerUpdateRequest);
+        final Runner foundRunnerJudy = runnerRepository.findById(runnerJudy.getId()).get();
+
+        // when, then
+        assertAll(
+                () -> assertThat(foundRunnerJudy.getMember().getMemberName().getValue()).isEqualTo(runnerUpdateRequest.name()),
+                () -> assertThat(foundRunnerJudy.getMember().getCompany().getValue()).isEqualTo(runnerUpdateRequest.company()),
+                () -> assertThat(foundRunnerJudy.getIntroduction().getValue()).isEqualTo(runnerUpdateRequest.introduction()),
+                () -> assertThat(getRunnerTechnicalTags(foundRunnerJudy)).isEqualTo(runnerUpdateRequest.technicalTags())
+        );
+    }
+
+    @NotNull
+    private List<String> getRunnerTechnicalTags(final Runner foundRunnerJudy) {
+        return foundRunnerJudy.getRunnerTechnicalTags().getRunnerTechnicalTags().stream()
+                .map(runnerTechnicalTag -> runnerTechnicalTag.getTechnicalTag().getTagName().getValue())
+                .toList();
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/RunnerPostTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/RunnerPostTest.java
@@ -276,4 +276,72 @@ class RunnerPostTest {
         // then
         assertThat(runnerPost.getRunnerPostTags().getRunnerPostTags()).hasSize(2);
     }
+
+    @DisplayName("Supporter 할당")
+    @Nested
+    class AssignSupporter {
+
+        @DisplayName("RunnerPost 내부의 Supporter 가 null 이며 ReviewStatus 가 NOT_STARTED 가 아니어야 하며 Deadline 이 끝나지 않은 경우 성공한다.")
+        @Test
+        void success_supporter_is_null_and_deadline_is_not_end() {
+            // given
+            final RunnerPost runnerPost = RunnerPost.builder()
+                    .title(new Title("JPA 정복"))
+                    .contents(new Contents("김영한 짱짱맨"))
+                    .pullRequestUrl(new PullRequestUrl("https://github.com/woowacourse-teams/2023-baton/pull/17"))
+                    .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
+                    .watchedCount(new WatchedCount(0))
+                    .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .runner(runner)
+                    .supporter(null)
+                    .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
+                    .build();
+
+            // then
+            assertThatCode(() -> runnerPost.assignSupporter(supporter))
+                    .doesNotThrowAnyException();
+        }
+
+        @DisplayName("RunnerPost 내부의 Supporter 가 null 이 아닐 때 예외가 발생한다.")
+        @Test
+        void fail_supporter_is_not_null() {
+            // given
+            final RunnerPost runnerPost = RunnerPost.builder()
+                    .title(new Title("JPA 정복"))
+                    .contents(new Contents("김영한 짱짱맨"))
+                    .pullRequestUrl(new PullRequestUrl("https://github.com/woowacourse-teams/2023-baton/pull/17"))
+                    .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
+                    .watchedCount(new WatchedCount(0))
+                    .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .runner(runner)
+                    .supporter(supporter)
+                    .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
+                    .build();
+
+            // then
+            assertThatThrownBy(() -> runnerPost.assignSupporter(supporter))
+                    .isInstanceOf(RunnerPostDomainException.class);
+        }
+
+        @DisplayName("RunnerPost 의 마감 기한이 이미 끝났을 때 예외가 발생한다.")
+        @Test
+        void fail_deadline_is_already_end() {
+            // given
+            final RunnerPost runnerPost = RunnerPost.builder()
+                    .title(new Title("JPA 정복"))
+                    .contents(new Contents("김영한 짱짱맨"))
+                    .pullRequestUrl(new PullRequestUrl("https://github.com/woowacourse-teams/2023-baton/pull/17"))
+                    .deadline(new Deadline(LocalDateTime.now().minusDays(100)))
+                    .watchedCount(new WatchedCount(0))
+                    .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .runner(runner)
+                    .supporter(supporter)
+                    .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
+                    .build();
+
+            // then
+            assertThatThrownBy(() -> runnerPost.assignSupporter(supporter))
+                    .isInstanceOf(RunnerPostDomainException.class);
+        }
+    }
 }

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/RunnerPostTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/RunnerPostTest.java
@@ -286,7 +286,7 @@ class RunnerPostTest {
     @Nested
     class AssignSupporter {
 
-        @DisplayName("RunnerPost 내부의 Supporter 가 null 이며 ReviewStatus 가 NOT_STARTED 가 아니어야 하며 Deadline 이 끝나지 않은 경우 성공한다.")
+        @DisplayName("RunnerPost 내부의 Supporter 가 null 이며 ReviewStatus 가 NOT_STARTED 이어야 하며 Deadline 이 끝나지 않은 경우 성공한다.")
         @Test
         void success_supporter_is_null_and_deadline_is_not_end() {
             // given

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/RunnerPostTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/RunnerPostTest.java
@@ -3,6 +3,9 @@ package touch.baton.domain.runnerpost;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import touch.baton.domain.common.vo.Contents;
 import touch.baton.domain.common.vo.Title;
 import touch.baton.domain.common.vo.WatchedCount;
@@ -28,7 +31,9 @@ import touch.baton.fixture.domain.RunnerTechnicalTagsFixture;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -343,5 +348,145 @@ class RunnerPostTest {
             assertThatThrownBy(() -> runnerPost.assignSupporter(supporter))
                     .isInstanceOf(RunnerPostDomainException.class);
         }
+    }
+
+    @DisplayName("RunnerPost ReviewStatus 수정")
+    @Nested
+    class UpdateReviewStatus {
+
+        @DisplayName("IN_PROGRESS 에서 DONE 으로 수정 성공한다.")
+        @Test
+        void success_IN_PROGRESS__to_DONE() {
+            // given
+            final RunnerPost runnerPost = RunnerPost.builder()
+                    .title(new Title("러너가 작성하는 리뷰 요청 게시글의 테스트 제목입니다."))
+                    .contents(new Contents("안녕하세요. 테스트 내용입니다."))
+                    .pullRequestUrl(new PullRequestUrl("https://github.com"))
+                    .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
+                    .watchedCount(new WatchedCount(0))
+                    .reviewStatus(ReviewStatus.IN_PROGRESS)
+                    .runner(runner)
+                    .supporter(supporter)
+                    .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
+                    .build();
+
+            // when
+            runnerPost.updateReviewStatus(ReviewStatus.DONE);
+
+            // then
+            assertThat(runnerPost.getReviewStatus()).isEqualTo(ReviewStatus.DONE);
+        }
+
+        @DisplayName("NOT_STARTED 에서 IN_PROGRESS 으로 수정 실패한다.")
+        @Test
+        void fail_NOT_STARTED__to_IN_PROGRESS() {
+            // given
+            final RunnerPost runnerPost = RunnerPost.builder()
+                    .title(new Title("러너가 작성하는 리뷰 요청 게시글의 테스트 제목입니다."))
+                    .contents(new Contents("안녕하세요. 테스트 내용입니다."))
+                    .pullRequestUrl(new PullRequestUrl("https://github.com"))
+                    .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
+                    .watchedCount(new WatchedCount(0))
+                    .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .runner(runner)
+                    .supporter(supporter)
+                    .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> runnerPost.updateReviewStatus(ReviewStatus.IN_PROGRESS))
+                    .isInstanceOf(RunnerPostDomainException.class);
+        }
+
+        @DisplayName("NOT_STARTED 에서 DONE 으로 수정 실패한다.")
+        @Test
+        void fail_NOT_STARTED__to_DONE() {
+            // given
+            final RunnerPost runnerPost = RunnerPost.builder()
+                    .title(new Title("러너가 작성하는 리뷰 요청 게시글의 테스트 제목입니다."))
+                    .contents(new Contents("안녕하세요. 테스트 내용입니다."))
+                    .pullRequestUrl(new PullRequestUrl("https://github.com"))
+                    .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
+                    .watchedCount(new WatchedCount(0))
+                    .reviewStatus(ReviewStatus.DONE)
+                    .runner(runner)
+                    .supporter(supporter)
+                    .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> runnerPost.updateReviewStatus(ReviewStatus.DONE))
+                    .isInstanceOf(RunnerPostDomainException.class);
+        }
+
+        @DisplayName("DONE 에서 NOT_STARTED 으로 수정 실패한다.")
+        @Test
+        void fail_DONE_to_NOT_STARTED() {
+            // given
+            final RunnerPost runnerPost = RunnerPost.builder()
+                    .title(new Title("러너가 작성하는 리뷰 요청 게시글의 테스트 제목입니다."))
+                    .contents(new Contents("안녕하세요. 테스트 내용입니다."))
+                    .pullRequestUrl(new PullRequestUrl("https://github.com"))
+                    .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
+                    .watchedCount(new WatchedCount(0))
+                    .reviewStatus(ReviewStatus.DONE)
+                    .runner(runner)
+                    .supporter(supporter)
+                    .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> runnerPost.updateReviewStatus(ReviewStatus.NOT_STARTED))
+                    .isInstanceOf(RunnerPostDomainException.class);
+        }
+
+        @DisplayName("DONE 에서 IN_PROGRESS 으로 수정 실패한다.")
+        @Test
+        void fail_DONE_to_IN_PROGRESS() {
+            // given
+            final RunnerPost runnerPost = RunnerPost.builder()
+                    .title(new Title("러너가 작성하는 리뷰 요청 게시글의 테스트 제목입니다."))
+                    .contents(new Contents("안녕하세요. 테스트 내용입니다."))
+                    .pullRequestUrl(new PullRequestUrl("https://github.com"))
+                    .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
+                    .watchedCount(new WatchedCount(0))
+                    .reviewStatus(ReviewStatus.DONE)
+                    .runner(runner)
+                    .supporter(supporter)
+                    .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> runnerPost.updateReviewStatus(ReviewStatus.IN_PROGRESS))
+                    .isInstanceOf(RunnerPostDomainException.class);
+        }
+
+        @DisplayName("같은 ReviewStatus 로 수정할 경우 실패한다.")
+        @ParameterizedTest
+        @MethodSource("reviewStatusDummy")
+        void fail_same_to_same(final ReviewStatus reviewStatus) {
+            // given
+            final RunnerPost runnerPost = RunnerPost.builder()
+                    .title(new Title("러너가 작성하는 리뷰 요청 게시글의 테스트 제목입니다."))
+                    .contents(new Contents("안녕하세요. 테스트 내용입니다."))
+                    .pullRequestUrl(new PullRequestUrl("https://github.com"))
+                    .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
+                    .watchedCount(new WatchedCount(0))
+                    .reviewStatus(reviewStatus)
+                    .runner(runner)
+                    .supporter(supporter)
+                    .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> runnerPost.updateReviewStatus(reviewStatus))
+                    .isInstanceOf(RunnerPostDomainException.class);
+        }
+
+        private static Stream<Arguments> reviewStatusDummy() {
+            return Arrays.stream(ReviewStatus.values())
+                    .map(Arguments::arguments);
+        }
+
     }
 }

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostRepositoryTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostRepositoryTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import touch.baton.config.RepositoryTestConfig;
 import touch.baton.domain.member.Member;
 import touch.baton.domain.member.repository.MemberRepository;
@@ -16,16 +15,16 @@ import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
 import touch.baton.domain.supporter.Supporter;
 import touch.baton.domain.supporter.repository.SupporterRepository;
+import touch.baton.domain.supporter.repository.SupporterRunnerPostRepository;
 import touch.baton.fixture.domain.MemberFixture;
 import touch.baton.fixture.domain.RunnerFixture;
 import touch.baton.fixture.domain.RunnerPostFixture;
 import touch.baton.fixture.domain.SupporterFixture;
+import touch.baton.fixture.domain.SupporterRunnerPostFixture;
 
 import java.time.LocalDateTime;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.springframework.data.domain.Sort.Order.desc;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class RunnerPostRepositoryTest extends RepositoryTestConfig {
 
@@ -41,30 +40,53 @@ class RunnerPostRepositoryTest extends RepositoryTestConfig {
     @Autowired
     private RunnerPostRepository runnerPostRepository;
 
+    @Autowired
+    private SupporterRunnerPostRepository supporterRunnerPostRepository;
+
     @DisplayName("Supporter 식별자값과 ReviewStatus 로 연관된 RunnerPost 를 페이징하여 조회한다.")
     @Test
     void findBySupporterIdAndReviewStatus() {
         // given
         final Member savedMemberDitoo = memberRepository.save(MemberFixture.createDitoo());
         final Runner savedRunnerDitoo = runnerRepository.save(RunnerFixture.createRunner(savedMemberDitoo));
+        final Member savedMemberEthan = memberRepository.save(MemberFixture.createEthan());
+        final Runner savedRunnerEthan = runnerRepository.save(RunnerFixture.createRunner(savedMemberEthan));
+        final Member savedMemberJudy = memberRepository.save(MemberFixture.createJudy());
+        final Runner savedRunnerJudy = runnerRepository.save(RunnerFixture.createRunner(savedMemberJudy));
 
-        final Member savedMemberHyena = memberRepository.save(MemberFixture.createDitoo());
+        final Member savedMemberHyena = memberRepository.save(MemberFixture.createHyena());
         final Supporter savedSupporterHyena = supporterRepository.save(SupporterFixture.create(savedMemberHyena));
 
-        final RunnerPost runnerPost = RunnerPostFixture.create(savedRunnerDitoo, new Deadline(LocalDateTime.now().plusHours(100)));
-        final RunnerPost savedRunnerPost = runnerPostRepository.save(runnerPost);
+        final RunnerPost runnerPostOne = RunnerPostFixture.create(savedRunnerDitoo, new Deadline(LocalDateTime.now().plusHours(100)));
+        final RunnerPost savedRunnerPostOne = runnerPostRepository.save(runnerPostOne);
+        final RunnerPost runnerPostTwo = RunnerPostFixture.create(savedRunnerEthan, new Deadline(LocalDateTime.now().plusHours(100)));
+        final RunnerPost savedRunnerPostTwo = runnerPostRepository.save(runnerPostTwo);
+        final RunnerPost runnerPostThree = RunnerPostFixture.create(savedRunnerJudy, new Deadline(LocalDateTime.now().plusHours(100)));
+        final RunnerPost savedRunnerPostThree = runnerPostRepository.save(runnerPostThree);
 
-        savedRunnerPost.assignSupporter(savedSupporterHyena);
+        savedRunnerPostOne.assignSupporter(savedSupporterHyena);
+        savedRunnerPostOne.updateReviewStatus(ReviewStatus.DONE);
+        savedRunnerPostTwo.assignSupporter(savedSupporterHyena);
+        savedRunnerPostTwo.updateReviewStatus(ReviewStatus.DONE);
+        savedRunnerPostThree.assignSupporter(savedSupporterHyena);
+        savedRunnerPostThree.updateReviewStatus(ReviewStatus.DONE);
+
+        supporterRunnerPostRepository.save(SupporterRunnerPostFixture.create(savedRunnerPostOne, savedSupporterHyena));
+        supporterRunnerPostRepository.save(SupporterRunnerPostFixture.create(savedRunnerPostTwo, savedSupporterHyena));
+        supporterRunnerPostRepository.save(SupporterRunnerPostFixture.create(savedRunnerPostThree, savedSupporterHyena));
 
         // when
-        final PageRequest pageRequest = PageRequest.of(1, 10, Sort.by(desc("createdAt")));
-        final Page<RunnerPost> pageRunnerPost
-                = runnerPostRepository.findBySupporterIdAndReviewStatus(pageRequest, savedSupporterHyena.getId(), ReviewStatus.IN_PROGRESS);
+        final PageRequest pageOne = PageRequest.of(0, 2);
+        final PageRequest pageTwo = PageRequest.of(1, 2);
 
-        // then
-        assertAll(
-                () -> assertThat(pageRunnerPost.getPageable()).isEqualTo(pageRequest),
-                () -> assertThat(pageRunnerPost.getContent()).containsExactly(runnerPost)
-        );
+        final Page<RunnerPost> pageOneRunnerPosts
+                = runnerPostRepository.findBySupporterIdAndReviewStatus(pageOne, savedSupporterHyena.getId(), ReviewStatus.DONE);
+        final Page<RunnerPost> pageTwoRunnerPosts
+                = runnerPostRepository.findBySupporterIdAndReviewStatus(pageTwo, savedSupporterHyena.getId(), ReviewStatus.DONE);
+
+        assertSoftly(softly -> {
+            softly.assertThat(pageOneRunnerPosts.getContent()).containsExactly(savedRunnerPostOne, savedRunnerPostTwo);
+            softly.assertThat(pageTwoRunnerPosts.getContent()).containsExactly(savedRunnerPostThree);
+        });
     }
 }

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostRepositoryTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostRepositoryTest.java
@@ -41,9 +41,9 @@ class RunnerPostRepositoryTest extends RepositoryTestConfig {
     @Autowired
     private RunnerPostRepository runnerPostRepository;
 
-    @DisplayName("서포터와 연관된 러너 게시글을 조인하여 조회한다.")
+    @DisplayName("Supporter 식별자값과 ReviewStatus 로 연관된 RunnerPost 를 페이징하여 조회한다.")
     @Test
-    void findBySupporterIdAndRunnerPostReviewStatusOrderByCreatedAtDesc() {
+    void findBySupporterIdAndReviewStatus() {
         // given
         final Member savedMemberDitoo = memberRepository.save(MemberFixture.createDitoo());
         final Runner savedRunnerDitoo = runnerRepository.save(RunnerFixture.createRunner(savedMemberDitoo));
@@ -57,7 +57,7 @@ class RunnerPostRepositoryTest extends RepositoryTestConfig {
         savedRunnerPost.assignSupporter(savedSupporterHyena);
 
         // when
-        final PageRequest pageRequest = PageRequest.of(0, 10, Sort.by(desc("createdAt")));
+        final PageRequest pageRequest = PageRequest.of(1, 10, Sort.by(desc("createdAt")));
         final Page<RunnerPost> pageRunnerPost
                 = runnerPostRepository.findBySupporterIdAndReviewStatus(pageRequest, savedSupporterHyena.getId(), ReviewStatus.IN_PROGRESS);
 

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostRepositoryTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostRepositoryTest.java
@@ -1,0 +1,70 @@
+package touch.baton.domain.runnerpost.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import touch.baton.config.RepositoryTestConfig;
+import touch.baton.domain.member.Member;
+import touch.baton.domain.member.repository.MemberRepository;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.repository.RunnerRepository;
+import touch.baton.domain.runnerpost.RunnerPost;
+import touch.baton.domain.runnerpost.vo.Deadline;
+import touch.baton.domain.runnerpost.vo.ReviewStatus;
+import touch.baton.domain.supporter.Supporter;
+import touch.baton.domain.supporter.repository.SupporterRepository;
+import touch.baton.fixture.domain.MemberFixture;
+import touch.baton.fixture.domain.RunnerFixture;
+import touch.baton.fixture.domain.RunnerPostFixture;
+import touch.baton.fixture.domain.SupporterFixture;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.data.domain.Sort.Order.desc;
+
+class RunnerPostRepositoryTest extends RepositoryTestConfig {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RunnerRepository runnerRepository;
+
+    @Autowired
+    private SupporterRepository supporterRepository;
+
+    @Autowired
+    private RunnerPostRepository runnerPostRepository;
+
+    @DisplayName("서포터와 연관된 러너 게시글을 조인하여 조회한다.")
+    @Test
+    void findBySupporterIdAndRunnerPostReviewStatusOrderByCreatedAtDesc() {
+        // given
+        final Member savedMemberDitoo = memberRepository.save(MemberFixture.createDitoo());
+        final Runner savedRunnerDitoo = runnerRepository.save(RunnerFixture.createRunner(savedMemberDitoo));
+
+        final Member savedMemberHyena = memberRepository.save(MemberFixture.createDitoo());
+        final Supporter savedSupporterHyena = supporterRepository.save(SupporterFixture.create(savedMemberHyena));
+
+        final RunnerPost runnerPost = RunnerPostFixture.create(savedRunnerDitoo, new Deadline(LocalDateTime.now().plusHours(100)));
+        final RunnerPost savedRunnerPost = runnerPostRepository.save(runnerPost);
+
+        savedRunnerPost.assignSupporter(savedSupporterHyena);
+
+        // when
+        final PageRequest pageRequest = PageRequest.of(0, 10, Sort.by(desc("createdAt")));
+        final Page<RunnerPost> pageRunnerPost
+                = runnerPostRepository.findBySupporterIdAndReviewStatus(pageRequest, savedSupporterHyena.getId(), ReviewStatus.IN_PROGRESS);
+
+        // then
+        assertAll(
+                () -> assertThat(pageRunnerPost.getPageable()).isEqualTo(pageRequest),
+                () -> assertThat(pageRunnerPost.getContent()).containsExactly(runnerPost)
+        );
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceCreateTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceCreateTest.java
@@ -36,7 +36,13 @@ class RunnerPostServiceCreateTest extends ServiceTestConfig {
 
     @BeforeEach
     void setUp() {
-        runnerPostService = new RunnerPostService(runnerPostRepository, runnerPostTagRepository, tagRepository, supporterRepository);
+        runnerPostService = new RunnerPostService(
+                runnerPostRepository,
+                runnerPostTagRepository,
+                tagRepository,
+                supporterRepository,
+                supporterRunnerPostRepository
+        );
     }
 
     @DisplayName("Runner post 저장에 성공한다.")

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceDeleteTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceDeleteTest.java
@@ -35,7 +35,13 @@ class RunnerPostServiceDeleteTest extends ServiceTestConfig {
 
     @BeforeEach
     void setUp() {
-        runnerPostService = new RunnerPostService(runnerPostRepository, runnerPostTagRepository, tagRepository, supporterRepository);
+        runnerPostService = new RunnerPostService(
+                runnerPostRepository,
+                runnerPostTagRepository,
+                tagRepository,
+                supporterRepository,
+                supporterRunnerPostRepository
+        );
     }
 
     @Disabled

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceReadTest.java
@@ -158,7 +158,7 @@ class RunnerPostServiceReadTest extends ServiceTestConfig {
         savedRunnerPost.assignSupporter(savedSupporterHyena);
 
         // when
-        final PageRequest pageable = PageRequest.of(0, 10);
+        final PageRequest pageable = PageRequest.of(1, 10);
         final Page<RunnerPost> pageRunnerPosts
                 = runnerPostService.readRunnerPostsBySupporterIdAndReviewStatus(pageable, savedSupporterHyena.getId(), ReviewStatus.IN_PROGRESS);
 

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceReadTest.java
@@ -51,7 +51,13 @@ class RunnerPostServiceReadTest extends ServiceTestConfig {
 
     @BeforeEach
     void setUp() {
-        runnerPostService = new RunnerPostService(runnerPostRepository, runnerPostTagRepository, tagRepository, supporterRepository);
+        runnerPostService = new RunnerPostService(
+                runnerPostRepository,
+                runnerPostTagRepository,
+                tagRepository,
+                supporterRepository,
+                supporterRunnerPostRepository
+        );
     }
 
     @DisplayName("RunnerPost 식별자로 RunnerPost 를 조회한다.")

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceReadTest.java
@@ -3,6 +3,8 @@ package touch.baton.domain.runnerpost.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import touch.baton.config.ServiceTestConfig;
 import touch.baton.domain.common.vo.Contents;
 import touch.baton.domain.common.vo.TagName;
@@ -21,6 +23,7 @@ import touch.baton.domain.runnerpost.exception.RunnerPostBusinessException;
 import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.PullRequestUrl;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
+import touch.baton.domain.supporter.Supporter;
 import touch.baton.domain.tag.RunnerPostTag;
 import touch.baton.domain.tag.RunnerPostTags;
 import touch.baton.domain.tag.Tag;
@@ -28,14 +31,18 @@ import touch.baton.fixture.domain.MemberFixture;
 import touch.baton.fixture.domain.RunnerFixture;
 import touch.baton.fixture.domain.RunnerPostFixture;
 import touch.baton.fixture.domain.RunnerTechnicalTagsFixture;
+import touch.baton.fixture.domain.SupporterFixture;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static touch.baton.fixture.vo.DeadlineFixture.deadline;
 
 class RunnerPostServiceReadTest extends ServiceTestConfig {
 
@@ -43,7 +50,13 @@ class RunnerPostServiceReadTest extends ServiceTestConfig {
 
     @BeforeEach
     void setUp() {
-        runnerPostService = new RunnerPostService(runnerPostRepository, runnerPostTagRepository, tagRepository, supporterRepository);
+        runnerPostService = new RunnerPostService(
+                runnerPostRepository,
+                runnerPostTagRepository,
+                tagRepository,
+                supporterRepository,
+                supporterRunnerPostRepository
+        );
     }
 
     @DisplayName("RunnerPost 식별자로 RunnerPost 를 조회한다.")
@@ -66,7 +79,7 @@ class RunnerPostServiceReadTest extends ServiceTestConfig {
                 .build();
         runnerRepository.save(runner);
 
-        final LocalDateTime deadline = LocalDateTime.now();
+        final LocalDateTime deadline = now();
         final RunnerPost runnerPost = RunnerPost.builder()
                 .title(new Title("제 코드 리뷰 좀 해주세요!!"))
                 .contents(new Contents("제 코드는 클린코드가 맞을까요?"))
@@ -117,7 +130,7 @@ class RunnerPostServiceReadTest extends ServiceTestConfig {
         memberRepository.save(ditoo);
         final Runner runner = RunnerFixture.createRunner(ditoo);
         runnerRepository.save(runner);
-        final RunnerPost expected = RunnerPostFixture.create(runner, new Deadline(LocalDateTime.now().plusHours(100)));
+        final RunnerPost expected = RunnerPostFixture.create(runner, new Deadline(now().plusHours(100)));
         runnerPostRepository.save(expected);
 
         // when
@@ -128,5 +141,31 @@ class RunnerPostServiceReadTest extends ServiceTestConfig {
             softly.assertThat(actual).hasSize(1);
             softly.assertThat(actual.get(0)).isEqualTo(expected);
         });
+    }
+
+    @DisplayName("Supporter 외래키와 ReviewStatus 로 러너 게시글을 조회한다.")
+    @Test
+    void readRunnerPostsBySupporterIdAndReviewStatus() {
+        // given
+        final Member savedMemberEthan = memberRepository.save(MemberFixture.createEthan());
+        final Runner savedRunnerEthan = runnerRepository.save(RunnerFixture.createRunner(savedMemberEthan));
+
+        final Member savedMemberHyena = memberRepository.save(MemberFixture.createHyena());
+        final Supporter savedSupporterHyena = supporterRepository.save(SupporterFixture.create(savedMemberHyena));
+
+        final RunnerPost runnerPost = RunnerPostFixture.create(savedRunnerEthan, deadline(now().plusHours(100)));
+        final RunnerPost savedRunnerPost = runnerPostRepository.save(runnerPost);
+        savedRunnerPost.assignSupporter(savedSupporterHyena);
+
+        // when
+        final PageRequest pageable = PageRequest.of(0, 10);
+        final Page<RunnerPost> pageRunnerPosts
+                = runnerPostService.readRunnerPostsBySupporterIdAndReviewStatus(pageable, savedSupporterHyena.getId(), ReviewStatus.IN_PROGRESS);
+
+        // then
+        assertAll(
+                () -> assertThat(pageRunnerPosts.getPageable()).isEqualTo(pageable),
+                () -> assertThat(pageRunnerPosts.getContent()).containsExactly(savedRunnerPost)
+        );
     }
 }

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceReadTest.java
@@ -32,6 +32,7 @@ import touch.baton.fixture.domain.RunnerFixture;
 import touch.baton.fixture.domain.RunnerPostFixture;
 import touch.baton.fixture.domain.RunnerTechnicalTagsFixture;
 import touch.baton.fixture.domain.SupporterFixture;
+import touch.baton.fixture.domain.SupporterRunnerPostFixture;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -157,8 +158,10 @@ class RunnerPostServiceReadTest extends ServiceTestConfig {
         final RunnerPost savedRunnerPost = runnerPostRepository.save(runnerPost);
         savedRunnerPost.assignSupporter(savedSupporterHyena);
 
+        supporterRunnerPostRepository.save(SupporterRunnerPostFixture.create(runnerPost, savedSupporterHyena));
+
         // when
-        final PageRequest pageable = PageRequest.of(1, 10);
+        final PageRequest pageable = PageRequest.of(0, 10);
         final Page<RunnerPost> pageRunnerPosts
                 = runnerPostService.readRunnerPostsBySupporterIdAndReviewStatus(pageable, savedSupporterHyena.getId(), ReviewStatus.IN_PROGRESS);
 

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceUpdateTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceUpdateTest.java
@@ -45,7 +45,13 @@ class RunnerPostServiceUpdateTest extends ServiceTestConfig {
 
     @BeforeEach
     void setUp() {
-        runnerPostService = new RunnerPostService(runnerPostRepository, runnerPostTagRepository, tagRepository, supporterRepository);
+        runnerPostService = new RunnerPostService(
+                runnerPostRepository,
+                runnerPostTagRepository,
+                tagRepository,
+                supporterRepository,
+                supporterRunnerPostRepository
+        );
     }
 
     @DisplayName("Runner Post 수정에 성공한다.")

--- a/backend/baton/src/test/java/touch/baton/domain/supporter/repository/SupporterRunnerPostRepositoryTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/supporter/repository/SupporterRunnerPostRepositoryTest.java
@@ -41,9 +41,9 @@ class SupporterRunnerPostRepositoryTest extends RepositoryTestConfig {
     @Autowired
     private RunnerPostRepository runnerPostRepository;
 
-    @DisplayName("서포터와 연관된 러너 게시글을 조인하여 조회한다.")
+    @DisplayName("러너 게시글 식별자값으로 서포터가 지원한 수를 count 한다.")
     @Test
-    void findBySupporterIdAndRunnerPostReviewStatusOrderByCreatedAtDesc() {
+    void countByRunnerPostIdIn() {
         // given
         final Member savedMemberDitoo = memberRepository.save(MemberFixture.createDitoo());
         final Runner savedRunnerDitoo = runnerRepository.save(RunnerFixture.createRunner(savedMemberDitoo));
@@ -51,23 +51,39 @@ class SupporterRunnerPostRepositoryTest extends RepositoryTestConfig {
         final Member savedMemberHyena = memberRepository.save(MemberFixture.createDitoo());
         final Supporter savedSupporterHyena = supporterRepository.save(SupporterFixture.create(savedMemberHyena));
 
-        final RunnerPost runnerPost = RunnerPostFixture.create(savedRunnerDitoo, new Deadline(now().plusHours(100)));
-        final RunnerPost savedRunnerPost = runnerPostRepository.save(runnerPost);
+        final RunnerPost savedRunnerPostOne = runnerPostRepository.save(RunnerPostFixture.create(savedRunnerDitoo, new Deadline(now().plusHours(100))));
+        final RunnerPost savedRunnerPostTwo = runnerPostRepository.save(RunnerPostFixture.create(savedRunnerDitoo, new Deadline(now().plusHours(100))));
+        final RunnerPost savedRunnerPostThree = runnerPostRepository.save(RunnerPostFixture.create(savedRunnerDitoo, new Deadline(now().plusHours(100))));
+        final RunnerPost savedRunnerPostFour = runnerPostRepository.save(RunnerPostFixture.create(savedRunnerDitoo, new Deadline(now().plusHours(100))));
 
-        savedRunnerPost.assignSupporter(savedSupporterHyena);
+        savedRunnerPostOne.assignSupporter(savedSupporterHyena);
+        savedRunnerPostTwo.assignSupporter(savedSupporterHyena);
+        savedRunnerPostThree.assignSupporter(savedSupporterHyena);
+        savedRunnerPostFour.assignSupporter(savedSupporterHyena);
 
-        final SupporterRunnerPost supporterRunnerPost = SupporterRunnerPost.builder()
-                .runnerPost(savedRunnerPost)
-                .supporter(savedSupporterHyena)
-                .message(new Message("안녕하세요. 서포터 헤나입니다."))
-                .build();
-        supporterRunnerPostRepository.save(supporterRunnerPost);
+        supporterRunnerPostRepository.save(createSupporterRunnerPost(savedSupporterHyena, savedRunnerPostOne));
+        supporterRunnerPostRepository.save(createSupporterRunnerPost(savedSupporterHyena, savedRunnerPostTwo));
+        supporterRunnerPostRepository.save(createSupporterRunnerPost(savedSupporterHyena, savedRunnerPostThree));
+        supporterRunnerPostRepository.save(createSupporterRunnerPost(savedSupporterHyena, savedRunnerPostFour));
 
         // when
-        final List<Long> runnerPostIds = List.of(savedRunnerPost.getId());
+        final List<Long> runnerPostIds = List.of(
+                savedRunnerPostOne.getId(),
+                savedRunnerPostTwo.getId(),
+                savedRunnerPostThree.getId(),
+                savedRunnerPostFour.getId()
+        );
         final List<Integer> foundRunnerPostsApplicantCounts = supporterRunnerPostRepository.countByRunnerPostIdIn(runnerPostIds);
 
         // then
-        assertThat(foundRunnerPostsApplicantCounts).containsExactly(1);
+        assertThat(foundRunnerPostsApplicantCounts).containsExactly(1, 1, 1, 1);
+    }
+
+    private SupporterRunnerPost createSupporterRunnerPost(final Supporter supporter, final RunnerPost runnerPost) {
+        return SupporterRunnerPost.builder()
+                .runnerPost(runnerPost)
+                .supporter(supporter)
+                .message(new Message("안녕하세요. 서포터 헤나입니다."))
+                .build();
     }
 }

--- a/backend/baton/src/test/java/touch/baton/domain/supporter/repository/SupporterRunnerPostRepositoryTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/supporter/repository/SupporterRunnerPostRepositoryTest.java
@@ -1,0 +1,73 @@
+package touch.baton.domain.supporter.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import touch.baton.config.RepositoryTestConfig;
+import touch.baton.domain.member.Member;
+import touch.baton.domain.member.repository.MemberRepository;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.repository.RunnerRepository;
+import touch.baton.domain.runnerpost.RunnerPost;
+import touch.baton.domain.runnerpost.repository.RunnerPostRepository;
+import touch.baton.domain.runnerpost.vo.Deadline;
+import touch.baton.domain.supporter.Supporter;
+import touch.baton.domain.supporter.SupporterRunnerPost;
+import touch.baton.domain.supporter.vo.Message;
+import touch.baton.fixture.domain.MemberFixture;
+import touch.baton.fixture.domain.RunnerFixture;
+import touch.baton.fixture.domain.RunnerPostFixture;
+import touch.baton.fixture.domain.SupporterFixture;
+
+import java.util.List;
+
+import static java.time.LocalDateTime.now;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SupporterRunnerPostRepositoryTest extends RepositoryTestConfig {
+
+    @Autowired
+    private SupporterRunnerPostRepository supporterRunnerPostRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RunnerRepository runnerRepository;
+
+    @Autowired
+    private SupporterRepository supporterRepository;
+
+    @Autowired
+    private RunnerPostRepository runnerPostRepository;
+
+    @DisplayName("서포터와 연관된 러너 게시글을 조인하여 조회한다.")
+    @Test
+    void findBySupporterIdAndRunnerPostReviewStatusOrderByCreatedAtDesc() {
+        // given
+        final Member savedMemberDitoo = memberRepository.save(MemberFixture.createDitoo());
+        final Runner savedRunnerDitoo = runnerRepository.save(RunnerFixture.createRunner(savedMemberDitoo));
+
+        final Member savedMemberHyena = memberRepository.save(MemberFixture.createDitoo());
+        final Supporter savedSupporterHyena = supporterRepository.save(SupporterFixture.create(savedMemberHyena));
+
+        final RunnerPost runnerPost = RunnerPostFixture.create(savedRunnerDitoo, new Deadline(now().plusHours(100)));
+        final RunnerPost savedRunnerPost = runnerPostRepository.save(runnerPost);
+
+        savedRunnerPost.assignSupporter(savedSupporterHyena);
+
+        final SupporterRunnerPost supporterRunnerPost = SupporterRunnerPost.builder()
+                .runnerPost(savedRunnerPost)
+                .supporter(savedSupporterHyena)
+                .message(new Message("안녕하세요. 서포터 헤나입니다."))
+                .build();
+        supporterRunnerPostRepository.save(supporterRunnerPost);
+
+        // when
+        final List<Long> runnerPostIds = List.of(savedRunnerPost.getId());
+        final List<Integer> foundRunnerPostsApplicantCounts = supporterRunnerPostRepository.countByRunnerPostIdIn(runnerPostIds);
+
+        // then
+        assertThat(foundRunnerPostsApplicantCounts).containsExactly(1);
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/domain/supporter/service/SupporterServiceTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/supporter/service/SupporterServiceTest.java
@@ -5,9 +5,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import touch.baton.config.ServiceTestConfig;
 import touch.baton.domain.member.Member;
+import touch.baton.domain.runner.Runner;
+import touch.baton.domain.runner.controller.response.RunnerResponse;
+import touch.baton.domain.runner.service.dto.RunnerUpdateRequest;
 import touch.baton.domain.supporter.Supporter;
 import touch.baton.domain.supporter.service.dto.SupporterUpdateRequest;
 import touch.baton.fixture.domain.MemberFixture;
+import touch.baton.fixture.domain.RunnerFixture;
 import touch.baton.fixture.domain.SupporterFixture;
 
 import java.util.List;

--- a/backend/baton/src/test/java/touch/baton/fixture/domain/SupporterRunnerPostFixture.java
+++ b/backend/baton/src/test/java/touch/baton/fixture/domain/SupporterRunnerPostFixture.java
@@ -1,0 +1,20 @@
+package touch.baton.fixture.domain;
+
+import touch.baton.domain.runnerpost.RunnerPost;
+import touch.baton.domain.supporter.Supporter;
+import touch.baton.domain.supporter.SupporterRunnerPost;
+import touch.baton.domain.supporter.vo.Message;
+
+public abstract class SupporterRunnerPostFixture {
+
+    private SupporterRunnerPostFixture() {
+    }
+
+    public static SupporterRunnerPost create(final RunnerPost runnerPost, final Supporter supporter) {
+        return SupporterRunnerPost.builder()
+                .runnerPost(runnerPost)
+                .supporter(supporter)
+                .message(new Message("안녕하세요. 테스트용 서포터입니다."))
+                .build();
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/fixture/vo/MessageFixture.java
+++ b/backend/baton/src/test/java/touch/baton/fixture/vo/MessageFixture.java
@@ -1,0 +1,13 @@
+package touch.baton.fixture.vo;
+
+import touch.baton.domain.supporter.vo.Message;
+
+public abstract class MessageFixture {
+
+    private MessageFixture() {
+    }
+
+    public static Message message(final String value) {
+        return new Message(value);
+    }
+}


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #275

## 참고사항
- MessageFixture 생성
- AssuredSupport 한글 사용으로 인해 메서드 파라미터 정렬이 안됩니다.
- ReviewStatus를 컨트롤러에서 받아올 수 있도록 Converter 작성했습니다.
- RunnerArgumentResolver에 있는 익명 러너(Runner)에 익명 사용자(Member)를 추가했습니다.
- 페이징 응답에 사용할 PageResponse 작성했습니다.
- 페이징 응답에 필요한 페이징 정보인 PageInfo를 작성했습니다.
- RunnerPost에 Supporter 할당시 예외 3가지 추가했습니다. (null, ReviewStatus, Deadline)
- Deadline에 초(second)가 생성시에 삭제될 수 있도록 생성자 내부 수정했습니다.
- 서브모듈 업데이트

