### PR TITLE
프로필 상세 보기 페이지 구현 (러너, 서포터)

### DIFF
--- a/frontend/src/components/RunnerPost/RunnerPostItem/RunnerPostItem.tsx
+++ b/frontend/src/components/RunnerPost/RunnerPostItem/RunnerPostItem.tsx
@@ -36,10 +36,14 @@ const RunnerPostItem = ({
         </S.TagContainer>
       </S.LeftSideContainer>
       <S.RightSideContainer>
-        <S.ProfileContainer>
-          <Avatar width="60px" height="60px" imageUrl={runnerProfile.imageUrl} />
-          <S.ProfileName>{runnerProfile.name}</S.ProfileName>
-        </S.ProfileContainer>
+        {runnerProfile ? (
+          <>
+            <S.ProfileContainer>
+              <Avatar width="60px" height="60px" imageUrl={runnerProfile.imageUrl} />
+              <S.ProfileName>{runnerProfile.name}</S.ProfileName>
+            </S.ProfileContainer>
+          </>
+        ) : null}
         <S.ChatViewContainer>
           <S.statisticsContainer>
             <S.statisticsImage src={eyeIcon} />

--- a/frontend/src/components/SupporterCard/SupporterCardItem/SupporterCardItem.tsx
+++ b/frontend/src/components/SupporterCard/SupporterCardItem/SupporterCardItem.tsx
@@ -19,7 +19,7 @@ const SupporterCardItem = ({ supporter }: Props) => {
   const { runnerPostId } = useParams();
 
   const { getToken } = useToken();
-  const { goToMyPage } = usePageRouter();
+  const { goToMyPage, goToSupporterProfilePage } = usePageRouter();
 
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
@@ -29,6 +29,10 @@ const SupporterCardItem = ({ supporter }: Props) => {
 
   const closeModal = () => {
     setIsModalOpen(false);
+  };
+
+  const viewProfile = () => {
+    goToSupporterProfilePage(supporter.supporterId);
   };
 
   const selectSupporter = () => {
@@ -73,7 +77,7 @@ const SupporterCardItem = ({ supporter }: Props) => {
         <S.Message> {supporter.message}</S.Message>
       </S.MessageContainer>
       <S.ButtonContainer>
-        <Button colorTheme="BLACK" width="94px" height="35px" fontSize="14px" fontWeight={700}>
+        <Button colorTheme="BLACK" width="94px" height="35px" fontSize="14px" fontWeight={700} onClick={viewProfile}>
           프로필 보기
         </Button>
         <Button colorTheme="WHITE" width="94px" height="35px" fontSize="14px" fontWeight={700} onClick={openModal}>

--- a/frontend/src/components/SupporterCard/SupporterCartList/SupporterCardList.tsx
+++ b/frontend/src/components/SupporterCard/SupporterCartList/SupporterCardList.tsx
@@ -14,20 +14,22 @@ const SupporterCardList = () => {
   const [supporterList, setSupporterList] = useState<Candidate[]>([]);
 
   useEffect(() => {
-    const getSupporterList = async () => {
-      const token = getToken()?.value;
-      if (!token) throw new Error('토큰이 존재하지 않습니다');
-
-      const result = await getRequest<GetSupporterCandidateResponse>(
-        `/posts/runner/${runnerPostId}/supporters`,
-        `Bearer ${token}`,
-      );
-
-      setSupporterList(result.data);
-    };
-
     getSupporterList();
   }, []);
+
+  const getSupporterList = async () => {
+    const token = getToken()?.value;
+    if (!token) throw new Error('토큰이 존재하지 않습니다');
+
+    getRequest(`/posts/runner/${runnerPostId}/supporters`, `Bearer ${token}`)
+      .then(async (response) => {
+        const data = await response.json();
+        setSupporterList(data.data);
+      })
+      .catch((error: Error) => {
+        alert(error.message);
+      });
+  };
 
   return (
     <S.SupporterCardListContainer>

--- a/frontend/src/hooks/usePageRouter.ts
+++ b/frontend/src/hooks/usePageRouter.ts
@@ -28,6 +28,10 @@ export const usePageRouter = () => {
     navigate(ROUTER_PATH.RESULT);
   };
 
+  const goToSupporterProfilePage = (supporterId: number) => {
+    navigate(ROUTER_PATH.SUPPORTER_PROFILE.replace(':supporterId', supporterId.toString()));
+  };
+
   const goBack = () => {
     navigate(-1);
   };
@@ -39,6 +43,7 @@ export const usePageRouter = () => {
     goToLoginPage,
     goToMyPage,
     goToCreationResultPage,
+    goToSupporterProfilePage,
     goBack,
   };
 };

--- a/frontend/src/hooks/usePageRouter.ts
+++ b/frontend/src/hooks/usePageRouter.ts
@@ -32,6 +32,10 @@ export const usePageRouter = () => {
     navigate(ROUTER_PATH.SUPPORTER_PROFILE.replace(':supporterId', supporterId.toString()));
   };
 
+  const goToRunnerProfilePage = (runnerId: number) => {
+    navigate(ROUTER_PATH.RUNNER_PROFILE.replace(':runnerId', runnerId.toString()));
+  };
+
   const goBack = () => {
     navigate(-1);
   };
@@ -44,6 +48,7 @@ export const usePageRouter = () => {
     goToMyPage,
     goToCreationResultPage,
     goToSupporterProfilePage,
+    goToRunnerProfilePage,
     goBack,
   };
 };

--- a/frontend/src/mocks/data/runnerProfileInfo.json
+++ b/frontend/src/mocks/data/runnerProfileInfo.json
@@ -1,4 +1,5 @@
 {
+  "runnerId": 1,
   "name": "헤나(러너)",
   "company": "우아한테크코스",
   "imageUrl": "https://via.placeholder.com/150",

--- a/frontend/src/mocks/data/supporterProfileInfo.json
+++ b/frontend/src/mocks/data/supporterProfileInfo.json
@@ -1,4 +1,5 @@
 {
+  "supporterId": 1,
   "name": "헤나(서포터)",
   "company": "우아한테크코스",
   "imageUrl": "https://",

--- a/frontend/src/mocks/data/supporterProfilePost.json
+++ b/frontend/src/mocks/data/supporterProfilePost.json
@@ -1,0 +1,31 @@
+{
+  "data": [
+    {
+      "runnerPostId": 1,
+      "title": "이 서포터가 완료한 리뷰 1",
+      "deadline": "마감기한",
+      "tags": ["java", "JAVA"],
+      "watchedCount": 341,
+      "applicantCount": 4,
+      "reviewStatus": "DONE"
+    },
+    {
+      "runnerPostId": 2,
+      "title": "이 서포터가 완료한 리뷰 2",
+      "deadline": "마감기한",
+      "tags": ["java", "JAVA"],
+      "watchedCount": 34,
+      "applicantCount": 41,
+      "reviewStatus": "DONE"
+    },
+    {
+      "runnerPostId": 3,
+      "title": "이 서포터가 완료한 리뷰 3",
+      "deadline": "마감기한",
+      "tags": ["java", "JAVA"],
+      "watchedCount": 2224,
+      "applicantCount": 4,
+      "reviewStatus": "DONE"
+    }
+  ]
+}

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -9,6 +9,7 @@ import myPageSupporterPost from './data/myPageSupporterPost.json';
 import runnerProfileInfo from './data/runnerProfileInfo.json';
 import supporterProfileInfo from './data/supporterProfileInfo.json';
 import supporterCandidate from './data/supporterCandidate.json';
+import supporterProfilePost from './data/supporterProfilePost.json';
 
 export const handlers = [
   rest.post('*/posts/runner/test', async (req, res, ctx) => {
@@ -96,5 +97,9 @@ export const handlers = [
 
   rest.get('*/profile/supporter/:supporterId', async (req, res, ctx) => {
     return res(ctx.status(200), ctx.set('Content-Type', 'application/json'), ctx.json(supporterProfileInfo));
+  }),
+
+  rest.get('*/posts/runner/search/:supporterId', async (req, res, ctx) => {
+    return res(ctx.status(200), ctx.set('Content-Type', 'application/json'), ctx.json(supporterProfilePost));
   }),
 ];

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -89,4 +89,12 @@ export const handlers = [
   rest.get('*/posts/runner/:runnerPostId/supporters', async (req, res, ctx) => {
     return res(ctx.status(200), ctx.set('Content-Type', 'application/json'), ctx.json(supporterCandidate));
   }),
+
+  rest.get('*/profile/runner/:runnerId', async (req, res, ctx) => {
+    return res(ctx.status(200), ctx.set('Content-Type', 'application/json'), ctx.json(runnerProfileInfo));
+  }),
+
+  rest.get('*/profile/supporter/:supporterId', async (req, res, ctx) => {
+    return res(ctx.status(200), ctx.set('Content-Type', 'application/json'), ctx.json(supporterProfileInfo));
+  }),
 ];

--- a/frontend/src/pages/ProfileEditPage.tsx
+++ b/frontend/src/pages/ProfileEditPage.tsx
@@ -9,10 +9,10 @@ import { useToken } from '@/hooks/useToken';
 import Layout from '@/layout/Layout';
 import {
   Profile,
-  RunnerProfileRequest,
-  RunnerProfileResponse,
-  SupporterProfileRequest,
-  SupporterProfileResponse,
+  PatchRunnerProfileRequest,
+  GetRunnerProfileResponse,
+  PatchSupporterProfileRequest,
+  GetSupporterProfileResponse,
 } from '@/types/profile';
 import { Technic } from '@/types/tags';
 import { deepEqual } from '@/utils/object';
@@ -24,8 +24,8 @@ const ProfileEditPage = () => {
 
   const [isRunner, setIsRunner] = useState(true);
 
-  const [runnerProfile, setRunnerProfile] = useState<RunnerProfileResponse | null>(null);
-  const [supporterProfile, setSupporterProfile] = useState<SupporterProfileResponse | null>(null);
+  const [runnerProfile, setRunnerProfile] = useState<GetRunnerProfileResponse | null>(null);
+  const [supporterProfile, setSupporterProfile] = useState<GetSupporterProfileResponse | null>(null);
 
   const [name, setName] = useState<string | null>(null);
   const [company, setCompany] = useState<string | null>(null);
@@ -156,7 +156,7 @@ const ProfileEditPage = () => {
     setIsModalOpen(false);
   };
 
-  const patchRunnerProfile = async (runnerProfile: RunnerProfileRequest) => {
+  const patchRunnerProfile = async (runnerProfile: PatchRunnerProfileRequest) => {
     const token = getToken()?.value;
     if (!token) {
       return alert('토큰이 존재하지 않습니다');
@@ -165,10 +165,10 @@ const ProfileEditPage = () => {
     const body = JSON.stringify(runnerProfile);
     const authorization = `Bearer ${token}`;
 
-    await patchRequest<RunnerProfileRequest>(`/profile/runner/me`, authorization, body);
+    await patchRequest<PatchRunnerProfileRequest>(`/profile/runner/me`, authorization, body);
   };
 
-  const patchSupporterProfile = async (supporterProfile: SupporterProfileRequest) => {
+  const patchSupporterProfile = async (supporterProfile: PatchSupporterProfileRequest) => {
     const token = getToken()?.value;
     if (!token) {
       return alert('토큰이 존재하지 않습니다');
@@ -177,7 +177,7 @@ const ProfileEditPage = () => {
     const body = JSON.stringify(supporterProfile);
     const authorization = `Bearer ${token}`;
 
-    patchRequest<SupporterProfileRequest>(`/profile/supporter/me`, authorization, body);
+    patchRequest<PatchSupporterProfileRequest>(`/profile/supporter/me`, authorization, body);
   };
 
   useEffect(() => {
@@ -188,7 +188,7 @@ const ProfileEditPage = () => {
       }
 
       const authorization = `Bearer ${token}`;
-      const result = await getRequest<RunnerProfileResponse>(`/profile/runner/me`, authorization);
+      const result = await getRequest<GetRunnerProfileResponse>(`/profile/runner/me`, authorization);
 
       setRunnerProfile(result);
 
@@ -204,7 +204,7 @@ const ProfileEditPage = () => {
       }
 
       const authorization = `Bearer ${token}`;
-      const result = await getRequest<SupporterProfileResponse>(`/profile/supporter/me`, authorization);
+      const result = await getRequest<GetSupporterProfileResponse>(`/profile/supporter/me`, authorization);
 
       setSupporterProfile(result);
 

--- a/frontend/src/pages/RunnerPostDetailPage.tsx
+++ b/frontend/src/pages/RunnerPostDetailPage.tsx
@@ -19,7 +19,7 @@ const RunnerPostPage = () => {
   const [runnerPost, setRunnerPost] = useState<GetDetailedRunnerPostResponse | null>(null);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
-  const { goToMainPage, goBack } = usePageRouter();
+  const { goToMainPage, goBack, goToRunnerProfilePage } = usePageRouter();
   const { runnerPostId } = useParams();
   const { getToken } = useToken();
 
@@ -99,6 +99,12 @@ const RunnerPostPage = () => {
     setIsModalOpen(false);
   };
 
+  const viewProfile = () => {
+    if (runnerPost) {
+      goToRunnerProfilePage(runnerPost?.runnerProfile.runnerId);
+    }
+  };
+
   return (
     <Layout>
       <S.RunnerPostContainer>
@@ -141,7 +147,7 @@ const RunnerPostPage = () => {
               <S.Contents>{runnerPost.contents}</S.Contents>
               <S.BottomContentContainer>
                 <S.LeftSideContainer>
-                  <S.ProfileContainer>
+                  <S.ProfileContainer onClick={viewProfile}>
                     <Avatar imageUrl={runnerPost.runnerProfile.imageUrl} />
                     <S.Profile>
                       <S.Name>{runnerPost.runnerProfile.name}</S.Name>
@@ -276,6 +282,8 @@ const S = {
     flex-direction: row;
     align-items: center;
     gap: 20px;
+
+    cursor: pointer;
   `,
 
   Profile: styled.div`

--- a/frontend/src/pages/RunnerProfilePage.tsx
+++ b/frontend/src/pages/RunnerProfilePage.tsx
@@ -1,0 +1,151 @@
+import { getRequest } from '@/api/fetch';
+import TechLabel from '@/components/TechLabel/TechLabel';
+import Avatar from '@/components/common/Avatar/Avatar';
+import Button from '@/components/common/Button/Button';
+import Layout from '@/layout/Layout';
+import { GetRunnerProfileResponse } from '@/types/profile';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { styled } from 'styled-components';
+import githubIcon from '@/assets/github-icon.svg';
+
+const RunnerProfilePage = () => {
+  const [runnerProfile, setRunnerProfile] = useState<GetRunnerProfileResponse | null>(null);
+
+  const { runnerId } = useParams();
+
+  useEffect(() => {
+    const fetchProfileData = async () => {
+      const profileResult = await getProfile();
+
+      setRunnerProfile(profileResult);
+    };
+
+    fetchProfileData();
+  }, [runnerId]);
+
+  const getProfile = async () => {
+    const data = await getRequest<GetRunnerProfileResponse>(`/profile/runner/${runnerId}`);
+
+    return data;
+  };
+
+  return (
+    <Layout>
+      <S.ProfileContainer>
+        <S.InfoContainer>
+          <Avatar
+            imageUrl={runnerProfile?.imageUrl || 'https://via.placeholder.com/150'}
+            width="100px"
+            height="100px"
+          />
+          <S.InfoDetailContainer>
+            <S.Name>{runnerProfile?.name}</S.Name>
+            <S.Company>{runnerProfile?.company}</S.Company>
+            <S.TechLabel>
+              {runnerProfile?.technicalTags.map((tag) => (
+                <TechLabel key={tag} tag={tag} />
+              ))}
+            </S.TechLabel>
+          </S.InfoDetailContainer>
+        </S.InfoContainer>
+      </S.ProfileContainer>
+
+      <S.IntroductionContainer>
+        <S.Introduction>{runnerProfile?.introduction}</S.Introduction>
+        <Button width="127px" height="43px" colorTheme="BLACK" fontWeight={700}>
+          <S.Anchor href={runnerProfile?.githubUrl} target="_blank">
+            <img src={githubIcon} />
+            <S.GoToGitHub>Github</S.GoToGitHub>
+          </S.Anchor>
+        </Button>
+      </S.IntroductionContainer>
+    </Layout>
+  );
+};
+
+export default RunnerProfilePage;
+
+const S = {
+  ProfileContainer: styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+
+    padding: 50px 0;
+  `,
+
+  InfoContainer: styled.div`
+    display: flex;
+    align-items: center;
+
+    gap: 20px;
+  `,
+
+  InfoDetailContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  `,
+
+  Name: styled.div`
+    font-size: 26px;
+    font-weight: 700;
+  `,
+
+  Company: styled.div`
+    font-size: 18px;
+  `,
+  TechLabel: styled.div`
+    display: flex;
+    gap: 8px;
+  `,
+
+  ButtonContainer: styled.div`
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  `,
+
+  RunnerSupporterButton: styled.button<{ $isSelected: boolean }>`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 95px;
+    height: 38px;
+    border-radius: 18px;
+    border: 1px solid ${({ $isSelected }) => ($isSelected ? 'white' : 'var(--baton-red)')};
+
+    background-color: ${({ $isSelected }) => ($isSelected ? 'var(--baton-red)' : 'white')};
+
+    color: ${({ $isSelected }) => ($isSelected ? 'white' : 'var(--baton-red)')};
+  `,
+
+  IntroductionContainer: styled.div`
+    display: flex;
+    justify-content: space-between;
+
+    padding: 0 10px;
+    margin-bottom: 50px;
+
+    border-left: 3px solid var(--gray-600);
+  `,
+
+  Introduction: styled.div`
+    width: 700px;
+
+    font-size: 18px;
+
+    white-space: no-wrap;
+  `,
+
+  Anchor: styled.a`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+  `,
+
+  GoToGitHub: styled.p``,
+};

--- a/frontend/src/pages/RunnerProfilePage.tsx
+++ b/frontend/src/pages/RunnerProfilePage.tsx
@@ -15,19 +15,19 @@ const RunnerProfilePage = () => {
   const { runnerId } = useParams();
 
   useEffect(() => {
-    const fetchProfileData = async () => {
-      const profileResult = await getProfile();
-
-      setRunnerProfile(profileResult);
-    };
-
-    fetchProfileData();
+    getProfile();
   }, [runnerId]);
 
   const getProfile = async () => {
-    const data = await getRequest<GetRunnerProfileResponse>(`/profile/runner/${runnerId}`);
+    getRequest(`/profile/runner/${runnerId}`)
+      .then(async (response) => {
+        const data: GetRunnerProfileResponse = await response.json();
 
-    return data;
+        setRunnerProfile(data);
+      })
+      .catch((error: Error) => {
+        alert(error.message);
+      });
   };
 
   return (

--- a/frontend/src/pages/SupporterProfilePage.tsx
+++ b/frontend/src/pages/SupporterProfilePage.tsx
@@ -8,24 +8,35 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { styled } from 'styled-components';
 import githubIcon from '@/assets/github-icon.svg';
+import { GetRunnerPostResponse } from '@/types/runnerPost';
+import RunnerPostItem from '@/components/RunnerPost/RunnerPostItem/RunnerPostItem';
 
 const SupporterProfilePage = () => {
   const [supporterProfile, setSupporterProfile] = useState<GetSupporterProfileResponse | null>(null);
+  const [supporterProfilePost, setSupporterProfilePost] = useState<GetRunnerPostResponse | null>(null);
 
   const { supporterId } = useParams();
 
   useEffect(() => {
-    const fetchProfileData = async () => {
+    const fetchProfilePageData = async () => {
       const profileResult = await getProfile();
+      const postResult = await getPost();
 
       setSupporterProfile(profileResult);
+      setSupporterProfilePost(postResult);
     };
 
-    fetchProfileData();
-  }, [supporterId]);
+    fetchProfilePageData();
+  }, []);
 
   const getProfile = async () => {
     const data = await getRequest<GetSupporterProfileResponse>(`/profile/supporter/${supporterId}`);
+
+    return data;
+  };
+
+  const getPost = async () => {
+    const data = await getRequest<GetRunnerPostResponse>(`/posts/runner/search/${supporterId}`);
 
     return data;
   };
@@ -60,6 +71,16 @@ const SupporterProfilePage = () => {
           </S.Anchor>
         </Button>
       </S.IntroductionContainer>
+
+      <S.ReviewCountWrapper>
+        <S.ReviewCountTitle>완료된 리뷰</S.ReviewCountTitle>
+        <S.ReviewCount>{supporterProfilePost?.data.length}</S.ReviewCount>
+      </S.ReviewCountWrapper>
+      <S.PostsContainer>
+        {supporterProfilePost?.data.map((runnerPostData) => (
+          <RunnerPostItem key={runnerPostData.runnerPostId} runnerPostData={runnerPostData} />
+        ))}
+      </S.PostsContainer>
     </Layout>
   );
 };
@@ -127,7 +148,7 @@ const S = {
     justify-content: space-between;
 
     padding: 0 10px;
-    margin-bottom: 50px;
+    margin-bottom: 80px;
 
     border-left: 3px solid var(--gray-600);
   `,
@@ -148,4 +169,27 @@ const S = {
   `,
 
   GoToGitHub: styled.p``,
+
+  PostsContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 30px;
+  `,
+
+  ReviewCountWrapper: styled.div`
+    display: flex;
+    align-items: center;
+    margin: 0 0 40px 20px;
+  `,
+
+  ReviewCountTitle: styled.span`
+    font-size: 30px;
+    margin-right: 15px;
+  `,
+
+  ReviewCount: styled.span`
+    font-size: 40px;
+    font-weight: 700;
+  `,
 };

--- a/frontend/src/pages/SupporterProfilePage.tsx
+++ b/frontend/src/pages/SupporterProfilePage.tsx
@@ -1,0 +1,151 @@
+import { getRequest } from '@/api/fetch';
+import TechLabel from '@/components/TechLabel/TechLabel';
+import Avatar from '@/components/common/Avatar/Avatar';
+import Button from '@/components/common/Button/Button';
+import Layout from '@/layout/Layout';
+import { GetSupporterProfileResponse } from '@/types/profile';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { styled } from 'styled-components';
+import githubIcon from '@/assets/github-icon.svg';
+
+const SupporterProfilePage = () => {
+  const [supporterProfile, setSupporterProfile] = useState<GetSupporterProfileResponse | null>(null);
+
+  const { supporterId } = useParams();
+
+  useEffect(() => {
+    const fetchProfileData = async () => {
+      const profileResult = await getProfile();
+
+      setSupporterProfile(profileResult);
+    };
+
+    fetchProfileData();
+  }, [supporterId]);
+
+  const getProfile = async () => {
+    const data = await getRequest<GetSupporterProfileResponse>(`/profile/supporter/${supporterId}`);
+
+    return data;
+  };
+
+  return (
+    <Layout>
+      <S.ProfileContainer>
+        <S.InfoContainer>
+          <Avatar
+            imageUrl={supporterProfile?.imageUrl || 'https://via.placeholder.com/150'}
+            width="100px"
+            height="100px"
+          />
+          <S.InfoDetailContainer>
+            <S.Name>{supporterProfile?.name}</S.Name>
+            <S.Company>{supporterProfile?.company}</S.Company>
+            <S.TechLabel>
+              {supporterProfile?.technicalTags.map((tag) => (
+                <TechLabel key={tag} tag={tag} />
+              ))}
+            </S.TechLabel>
+          </S.InfoDetailContainer>
+        </S.InfoContainer>
+      </S.ProfileContainer>
+
+      <S.IntroductionContainer>
+        <S.Introduction>{supporterProfile?.introduction}</S.Introduction>
+        <Button width="127px" height="43px" colorTheme="BLACK" fontWeight={700}>
+          <S.Anchor href={supporterProfile?.githubUrl} target="_blank">
+            <img src={githubIcon} />
+            <S.GoToGitHub>Github</S.GoToGitHub>
+          </S.Anchor>
+        </Button>
+      </S.IntroductionContainer>
+    </Layout>
+  );
+};
+
+export default SupporterProfilePage;
+
+const S = {
+  ProfileContainer: styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+
+    padding: 50px 0;
+  `,
+
+  InfoContainer: styled.div`
+    display: flex;
+    align-items: center;
+
+    gap: 20px;
+  `,
+
+  InfoDetailContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  `,
+
+  Name: styled.div`
+    font-size: 26px;
+    font-weight: 700;
+  `,
+
+  Company: styled.div`
+    font-size: 18px;
+  `,
+  TechLabel: styled.div`
+    display: flex;
+    gap: 8px;
+  `,
+
+  ButtonContainer: styled.div`
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  `,
+
+  RunnerSupporterButton: styled.button<{ $isSelected: boolean }>`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 95px;
+    height: 38px;
+    border-radius: 18px;
+    border: 1px solid ${({ $isSelected }) => ($isSelected ? 'white' : 'var(--baton-red)')};
+
+    background-color: ${({ $isSelected }) => ($isSelected ? 'var(--baton-red)' : 'white')};
+
+    color: ${({ $isSelected }) => ($isSelected ? 'white' : 'var(--baton-red)')};
+  `,
+
+  IntroductionContainer: styled.div`
+    display: flex;
+    justify-content: space-between;
+
+    padding: 0 10px;
+    margin-bottom: 50px;
+
+    border-left: 3px solid var(--gray-600);
+  `,
+
+  Introduction: styled.div`
+    width: 700px;
+
+    font-size: 18px;
+
+    white-space: no-wrap;
+  `,
+
+  Anchor: styled.a`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+  `,
+
+  GoToGitHub: styled.p``,
+};

--- a/frontend/src/pages/SupporterProfilePage.tsx
+++ b/frontend/src/pages/SupporterProfilePage.tsx
@@ -18,27 +18,32 @@ const SupporterProfilePage = () => {
   const { supporterId } = useParams();
 
   useEffect(() => {
-    const fetchProfilePageData = async () => {
-      const profileResult = await getProfile();
-      const postResult = await getPost();
+    getProfile();
+    getPost();
+  }, [supporterId]);
 
-      setSupporterProfile(profileResult);
-      setSupporterProfilePost(postResult);
-    };
+  const getProfile = () => {
+    getRequest(`/profile/supporter/${supporterId}`)
+      .then(async (response) => {
+        const data: GetSupporterProfileResponse = await response.json();
 
-    fetchProfilePageData();
-  }, []);
-
-  const getProfile = async () => {
-    const data = await getRequest<GetSupporterProfileResponse>(`/profile/supporter/${supporterId}`);
-
-    return data;
+        setSupporterProfile(data);
+      })
+      .catch((error: Error) => {
+        alert(error.message);
+      });
   };
 
   const getPost = async () => {
-    const data = await getRequest<GetRunnerPostResponse>(`/posts/runner/search/${supporterId}`);
+    getRequest(`/posts/runner/search/${supporterId}`)
+      .then(async (response) => {
+        const data: GetRunnerPostResponse = await response.json();
 
-    return data;
+        setSupporterProfilePost(data);
+      })
+      .catch((error: Error) => {
+        alert(error.message);
+      });
   };
 
   return (

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -10,6 +10,8 @@ import MyPage from './pages/MyPage';
 import GithubCallbackPage from './pages/GithubCallbackPage';
 import ProfileEditPage from './pages/ProfileEditPage';
 import SupporterSelectPage from './pages/SupporterSelectPage';
+import SupporterProfilePage from './pages/SupporterProfilePage';
+import RunnerProfilePage from './pages/RunnerProfilePage';
 
 export const ROUTER_PATH = {
   MAIN: '/',
@@ -20,6 +22,8 @@ export const ROUTER_PATH = {
   LOGIN: '/login',
   NOT_FOUND: '/*',
   RESULT: '/result',
+  RUNNER_PROFILE: '/runner-profile/:runnerId',
+  SUPPORTER_PROFILE: '/supporter-profile/:supporterId',
   PROFILE_EDIT: '/profile-edit',
   GITHUB_CALLBACK: '/oauth/github/callback', // Authorization callback URL?
 };
@@ -61,6 +65,14 @@ export const router = createBrowserRouter(
         {
           path: ROUTER_PATH.SUPPORTER_SELECT,
           element: <SupporterSelectPage />,
+        },
+        {
+          path: ROUTER_PATH.RUNNER_PROFILE,
+          element: <RunnerProfilePage />,
+        },
+        {
+          path: ROUTER_PATH.SUPPORTER_PROFILE,
+          element: <SupporterProfilePage />,
         },
       ],
     },

--- a/frontend/src/types/profile.ts
+++ b/frontend/src/types/profile.ts
@@ -1,26 +1,12 @@
-import { ReviewStatus } from './runnerPost';
 import { Technic } from './tags';
 
-export interface GetRunnerProfileResponse {
-  profile: Profile;
-  runnerPosts: ProfileRunnerPost[];
-}
+export interface GetRunnerProfileResponse extends Profile {}
 
-export interface ProfileRunnerPost {
-  runnerPostId: number;
-  title: string;
-  deadline: string;
-  tags: string[];
-  reviewStatus: ReviewStatus;
-}
+export interface GetSupporterProfileResponse extends Profile {}
 
-export interface RunnerProfileResponse extends Profile {}
+export interface PatchRunnerProfileRequest extends ProfileRequest {}
 
-export interface SupporterProfileResponse extends Profile {}
-
-export interface RunnerProfileRequest extends ProfileRequest {}
-
-export interface SupporterProfileRequest extends ProfileRequest {}
+export interface PatchSupporterProfileRequest extends ProfileRequest {}
 
 export type ProfileRequest = Omit<Profile, 'githubUrl' | 'imageUrl'>;
 

--- a/frontend/src/types/runnerPost.ts
+++ b/frontend/src/types/runnerPost.ts
@@ -9,7 +9,7 @@ export interface RunnerPost {
   title: string;
   deadline: string;
   tags: string[];
-  runnerProfile: RunnerProfile;
+  runnerProfile?: RunnerProfile;
   watchedCount: number;
   applicantCount: number;
   reviewStatus: ReviewStatus;


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #351 

## 참고사항

### 기능목록

![Aug-15-2023 18-47-32](https://github.com/woowacourse-teams/2023-baton/assets/62369936/e1d2664e-86ae-4d7b-bc65-040660667481)

- [x] 프로필 상세 보기 페이지 구현
- [x] 프로필 사진 누르면 상세보기로 이동할 수 있어야 한다.
  - [x] 러너는 게시물 내의 프로필을 누르면 상세정보로 이동
  - [x] 서포터는 서포터 선택에서 프로필 보기 버튼을 누르면 상세정보로 이동
- [x] 서포터 완료한 리뷰 게시글 전체 조회

🤔 러너는 어떤 글을 보여줘야할지 논의가 필요함!