### PR TITLE
메인페이지 더보기 기능 추가

### DIFF
--- a/frontend/src/components/RunnerPost/RunnerPostList/RunnerPostList.tsx
+++ b/frontend/src/components/RunnerPost/RunnerPostList/RunnerPostList.tsx
@@ -1,30 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { styled } from 'styled-components';
 import RunnerPostItem from '../RunnerPostItem/RunnerPostItem';
-import { GetRunnerPostResponse } from '@/types/runnerPost';
-import { getRequest } from '@/api/fetch';
+import { RunnerPost } from '@/types/runnerPost';
 
-const RunnerPostList = () => {
-  const [runnerPostList, setRunnerPostList] = useState<GetRunnerPostResponse | null>(null);
+interface Props {
+  posts: RunnerPost[];
+}
 
-  useEffect(() => {
-    getRunnerPost();
-  }, []);
-
-  const getRunnerPost = () => {
-    getRequest('/posts/runner/test')
-      .then(async (response) => {
-        const data = await response.json();
-        setRunnerPostList(data);
-      })
-      .catch((error: Error) => {
-        alert('게시글 목록을 불러오지 못했습니다.' + error.message);
-      });
-  };
-
+const RunnerPostList = ({ posts }: Props) => {
   return (
     <S.RunnerPostWrapper>
-      {runnerPostList?.data.map((runnerPostData) => (
+      {posts.map((runnerPostData) => (
         <RunnerPostItem key={runnerPostData.runnerPostId} runnerPostData={runnerPostData} />
       ))}
     </S.RunnerPostWrapper>

--- a/frontend/src/mocks/data/runnerPostList.json
+++ b/frontend/src/mocks/data/runnerPostList.json
@@ -123,5 +123,14 @@
       "applicantCount": 4,
       "reviewStatus": "NOT_STARTED"
     }
-  ]
+  ],
+  "pageInfo": {
+    "isFirst": true,
+    "isLast": false,
+    "hasNext": true,
+    "totalPages": 4,
+    "totalElements": 48,
+    "currentPage": 1,
+    "currentSize": 12
+  }
 }

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,15 +1,22 @@
+import { getRequest } from '@/api/fetch';
 import RunnerPostList from '@/components/RunnerPost/RunnerPostList/RunnerPostList';
 import Button from '@/components/common/Button/Button';
-import Tag from '@/components/common/Tag/Tag';
 import { usePageRouter } from '@/hooks/usePageRouter';
 import { useToken } from '@/hooks/useToken';
 import Layout from '@/layout/Layout';
-import React from 'react';
+import { GetRunnerPostResponse, RunnerPost } from '@/types/runnerPost';
+import React, { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 
 const MainPage = () => {
   const { goToRunnerPostCreatePage, goToLoginPage } = usePageRouter();
   const { getToken } = useToken();
+  const [runnerPostList, setRunnerPostList] = useState<RunnerPost[]>([]);
+  const [isLast, setIsLast] = useState<boolean>(true);
+
+  useEffect(() => {
+    getRunnerPost();
+  }, []);
 
   const handleClickPostButton = () => {
     const isLogin = !!getToken();
@@ -23,6 +30,18 @@ const MainPage = () => {
     }
 
     goToRunnerPostCreatePage();
+  };
+
+  const getRunnerPost = () => {
+    getRequest('/posts/runner/test')
+      .then(async (response) => {
+        const data: GetRunnerPostResponse = await response.json();
+        setRunnerPostList([...runnerPostList, ...data.data]);
+        setIsLast(data.pageInfo.isLast);
+      })
+      .catch((error: Error) => {
+        alert(error.message);
+      });
   };
 
   return (
@@ -47,9 +66,14 @@ const MainPage = () => {
           리뷰 요청 글 작성하기
         </Button>
       </S.ControlPanelContainer>
-      <S.RunnerPostWrapper>
-        <RunnerPostList />
-      </S.RunnerPostWrapper>
+      <S.RunnerPostContainer>
+        <RunnerPostList posts={runnerPostList} />
+        {!isLast && (
+          <Button colorTheme="RED" width="720px" onClick={getRunnerPost}>
+            더보기
+          </Button>
+        )}
+      </S.RunnerPostContainer>
     </Layout>
   );
 };
@@ -108,5 +132,10 @@ const S = {
     gap: 10px;
   `,
 
-  RunnerPostWrapper: styled.div``,
+  RunnerPostContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 50px;
+  `,
 };

--- a/frontend/src/types/runnerPost.ts
+++ b/frontend/src/types/runnerPost.ts
@@ -2,6 +2,7 @@ export type ReviewStatus = 'NOT_STARTED' | 'IN_PROGRESS' | 'DONE';
 
 export interface GetRunnerPostResponse {
   data: RunnerPost[];
+  pageInfo: PageInfo;
 }
 
 export interface RunnerPost {
@@ -44,4 +45,14 @@ export interface CreateRunnerPostRequest {
   pullRequestUrl: string;
   deadline: string;
   contents: string;
+}
+
+export interface PageInfo {
+  isFirst: boolean;
+  isLast: boolean;
+  hasNext: boolean;
+  totalPages: number;
+  totalElements: number;
+  currentPage: number;
+  currentSize: number;
 }


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #255 

## 참고사항
- 메인 페이지 더보기 기능 추가
- `MainPage`에 더보기 버튼이 추가됨에 따라 게시글 목록을 Props로 넘겨주도록 변경했습니다.
- msw에선 같은 목록을 무한히 주기 때문에 각 item key가 중복되서 console에 에러가 출력됩니다.
- msw 기능 고도화가 필요할 지는 논의가 필요할 듯 해요.

<img width="1379" alt="image" src="https://github.com/woowacourse-teams/2023-baton/assets/116625502/82426929-28ba-4dc1-9ce2-aae65b67f6a8">
