### PR TITLE
docs: 기존 Restdocs 정리

### DIFF
--- a/backend/baton/src/docs/asciidoc/MemberLoginReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/MemberLoginReadApi.adoc
@@ -10,8 +10,6 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-=== *로그인된 사용자 프로필 조회*
-
 ==== *로그인된 사용자 프로필 조회 API*
 
 ===== *Http Request*

--- a/backend/baton/src/docs/asciidoc/RunneReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunneReadApi.adoc
@@ -10,8 +10,6 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-=== *러너 프로필 조회*
-
 ==== *러너 프로필 조회 API*
 
 ===== *Http Request*
@@ -25,3 +23,25 @@ include::{snippets}/../../build/generated-snippets/runner-read-by-runner-id-api-
 ===== *Http Response Fields*
 
 include::{snippets}/../../build/generated-snippets/runner-read-by-runner-id-api-test/read-runner-profile/response-fields.adoc[]
+
+==== *러너 마이페이지 게시글 조회 API*
+
+===== *Http Request*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/http-request.adoc[]
+
+===== *Http Request Headers*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/request-headers.adoc[]
+
+===== *Http Request Query Parameters*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/query-parameters.adoc[]
+
+===== *Http Response*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/http-response.adoc[]
+
+===== *Http Response Fields*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/response-fields.adoc[]

--- a/backend/baton/src/docs/asciidoc/RunneReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunneReadApi.adoc
@@ -24,24 +24,3 @@ include::{snippets}/../../build/generated-snippets/runner-read-by-runner-id-api-
 
 include::{snippets}/../../build/generated-snippets/runner-read-by-runner-id-api-test/read-runner-profile/response-fields.adoc[]
 
-==== *러너 마이페이지 게시글 조회 API*
-
-===== *Http Request*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/http-request.adoc[]
-
-===== *Http Request Headers*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/request-headers.adoc[]
-
-===== *Http Request Query Parameters*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/query-parameters.adoc[]
-
-===== *Http Response*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/http-response.adoc[]
-
-===== *Http Response Fields*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/response-fields.adoc[]

--- a/backend/baton/src/docs/asciidoc/RunnerLoginReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerLoginReadApi.adoc
@@ -10,9 +10,7 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-=== *로그인된 러너 프로필 조회*
-
-==== *로그인된 러너 마이페이지 프로필 조회 API*
+==== *러너 마이페이지 프로필 조회 API*
 
 ===== *Http Request*
 

--- a/backend/baton/src/docs/asciidoc/RunnerPostCreateApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerPostCreateApi.adoc
@@ -10,8 +10,6 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-=== *러너 게시글 생성*
-
 ==== *러너 게시글 생성 API*
 
 ===== *Http Request*

--- a/backend/baton/src/docs/asciidoc/RunnerPostCreateReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerPostCreateReadApi.adoc
@@ -10,9 +10,7 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-=== *러너 게시글 생성 API*
-
-==== *러너 게시글에 서포터 리뷰 지원 API*
+==== *서포터 리뷰 지원 API*
 
 ===== *Http Request*
 

--- a/backend/baton/src/docs/asciidoc/RunnerPostCreateReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerPostCreateReadApi.adoc
@@ -14,24 +14,24 @@ endif::[]
 
 ===== *Http Request*
 
-include::{snippets}/../../build/generated-snippets/runner-post-create-api-test/create-runner-post-applicant/http-request.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-applicant-api-test/create-runner-post-applicant/http-request.adoc[]
 
 ===== *Http Request Headers*
 
-include::{snippets}/../../build/generated-snippets/runner-post-create-api-test/create-runner-post-applicant/request-headers.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-applicant-api-test/create-runner-post-applicant/request-headers.adoc[]
 
 ===== *Http Request Path Parameters*
 
-include::{snippets}/../../build/generated-snippets/runner-post-create-api-test/create-runner-post-applicant/path-parameters.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-applicant-api-test/create-runner-post-applicant/path-parameters.adoc[]
 
 ===== *Http Request Fields*
 
-include::{snippets}/../../build/generated-snippets/runner-post-create-api-test/create-runner-post-applicant/request-fields.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-applicant-api-test/create-runner-post-applicant/request-fields.adoc[]
 
 ===== *Http Response*
 
-include::{snippets}/../../build/generated-snippets/runner-post-create-api-test/create-runner-post-applicant/http-response.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-applicant-api-test/create-runner-post-applicant/http-response.adoc[]
 
 ===== *Http Response Headers*
 
-include::{snippets}/../../build/generated-snippets/runner-post-create-api-test/create-runner-post-applicant/response-headers.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-applicant-api-test/create-runner-post-applicant/response-headers.adoc[]

--- a/backend/baton/src/docs/asciidoc/RunnerPostCreateReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerPostCreateReadApi.adoc
@@ -10,7 +10,7 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-==== *서포터 리뷰 지원 API*
+==== *서포터 러너 게시글 리뷰 신청 API*
 
 ===== *Http Request*
 

--- a/backend/baton/src/docs/asciidoc/RunnerPostDeleteApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerPostDeleteApi.adoc
@@ -10,8 +10,6 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-=== *러너 게시글 삭제*
-
 ==== *러너 게시글 삭제 API*
 
 ===== *Http Request*

--- a/backend/baton/src/docs/asciidoc/RunnerPostReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerPostReadApi.adoc
@@ -32,24 +32,42 @@ include::{snippets}/../../build/generated-snippets/runner-post-read-one-api-test
 
 include::{snippets}/../../build/generated-snippets/runner-post-read-one-api-test/read-by-runner-post-id/response-fields.adoc[]
 
+==== *러너 게시글 전체 조회 API*
+
+===== *Http Request*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-all-runner-posts/http-request.adoc[]
+
+===== *Http Request Query Parameters*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-all-runner-posts/query-parameters.adoc[]
+
+===== *Http Response*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-all-runner-posts/http-response.adoc[]
+
+===== *Http Response Fields*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-all-runner-posts/response-fields.adoc[]
+
 ==== *리뷰 지원한 서포터 조회 API*
 
 ===== *Http Request*
 
-include::{snippets}/../../build/generated-snippets/runner-post-read-api-test/read-supporter-runner-posts-by-runner-post-id/http-request.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-supporter-runner-posts-by-runner-post-id/http-request.adoc[]
 
 ===== *Http Request Headers*
 
-include::{snippets}/../../build/generated-snippets/runner-post-read-one-api-test/read-by-runner-post-id/request-headers.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-supporter-runner-posts-by-runner-post-id/request-headers.adoc[]
 
 ===== *Http Request Path Parameters*
 
-include::{snippets}/../../build/generated-snippets/runner-post-read-api-test/read-supporter-runner-posts-by-runner-post-id/path-parameters.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-supporter-runner-posts-by-runner-post-id/path-parameters.adoc[]
 
 ===== *Http Response*
 
-include::{snippets}/../../build/generated-snippets/runner-post-read-api-test/read-supporter-runner-posts-by-runner-post-id/http-response.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-supporter-runner-posts-by-runner-post-id/http-response.adoc[]
 
 ===== *Http Response Fields*
 
-include::{snippets}/../../build/generated-snippets/runner-post-read-api-test/read-supporter-runner-posts-by-runner-post-id/response-fields.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-supporter-runner-posts-by-runner-post-id/response-fields.adoc[]

--- a/backend/baton/src/docs/asciidoc/RunnerPostReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerPostReadApi.adoc
@@ -10,29 +10,7 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-=== *러너 게시글 조회*
-
-==== *서포터가 연관된 러너 게시글 조회 API*
-
-===== *Http Request*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-referenced-by-supporter/http-request.adoc[]
-
-===== *Http Request Query Parameters*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-referenced-by-supporter/query-parameters.adoc[]
-
-===== *Http Response*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-referenced-by-supporter/http-response.adoc[]
-
-===== *Http Response Fields*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-referenced-by-supporter/response-fields.adoc[]
-
-=== *러너 게시글 상세 조회*
-
-==== *러너 게시글 단건 상세 조회 API*
+==== *러너 게시글 상세 조회 API*
 
 ===== *Http Request*
 
@@ -54,7 +32,7 @@ include::{snippets}/../../build/generated-snippets/runner-post-read-one-api-test
 
 include::{snippets}/../../build/generated-snippets/runner-post-read-one-api-test/read-by-runner-post-id/response-fields.adoc[]
 
-==== *서포터 러너 게시글 조회 API*
+==== *리뷰 지원한 서포터 조회 API*
 
 ===== *Http Request*
 
@@ -75,25 +53,3 @@ include::{snippets}/../../build/generated-snippets/runner-post-read-api-test/rea
 ===== *Http Response Fields*
 
 include::{snippets}/../../build/generated-snippets/runner-post-read-api-test/read-supporter-runner-posts-by-runner-post-id/response-fields.adoc[]
-
-==== * 러너 마이페이지 게시글 조회 API*
-
-===== *Http Request*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/http-request.adoc[]
-
-===== *Http Request Headers*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/request-headers.adoc[]
-
-===== *Http Request Query Parameters*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/query-parameters.adoc[]
-
-===== *Http Response*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/http-response.adoc[]
-
-===== *Http Response Fields*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/response-fields.adoc[]

--- a/backend/baton/src/docs/asciidoc/RunnerPostReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerPostReadApi.adoc
@@ -50,6 +50,28 @@ include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test
 
 include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-all-runner-posts/response-fields.adoc[]
 
+==== *러너 마이페이지 게시글 조회 API*
+
+===== *Http Request*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/http-request.adoc[]
+
+===== *Http Request Headers*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/request-headers.adoc[]
+
+===== *Http Request Query Parameters*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/query-parameters.adoc[]
+
+===== *Http Response*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/http-response.adoc[]
+
+===== *Http Response Fields*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-runner-my-page/response-fields.adoc[]
+
 ==== *리뷰 지원한 서포터 조회 API*
 
 ===== *Http Request*
@@ -71,3 +93,39 @@ include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter
 ===== *Http Response Fields*
 
 include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-supporter-runner-posts-by-runner-post-id/response-fields.adoc[]
+
+==== *서포터 마이페이지 러너 게시글 조회 API (queryParam)*
+
+===== *Http Request*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-with-logined-supporter-api-test/read-runner-posts-by-logined-supporter-and-review-status/http-request.adoc[]
+
+===== *Http Request Query Parameters*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-with-logined-supporter-api-test/read-runner-posts-by-logined-supporter-and-review-status/query-parameters.adoc[]
+
+===== *Http Response*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-with-logined-supporter-api-test/read-runner-posts-by-logined-supporter-and-review-status/http-response.adoc[]
+
+===== *Http Response Fields*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-with-logined-supporter-api-test/read-runner-posts-by-logined-supporter-and-review-status/response-fields.adoc[]
+
+==== *서포터 리뷰 완료한 게시글 조회 API*
+
+===== *Http Request*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-referenced-by-supporter/http-request.adoc[]
+
+===== *Http Request Query Parameters*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-referenced-by-supporter/query-parameters.adoc[]
+
+===== *Http Response*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-referenced-by-supporter/http-response.adoc[]
+
+===== *Http Response Fields*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-referenced-by-supporter/response-fields.adoc[]

--- a/backend/baton/src/docs/asciidoc/RunnerPostReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerPostReadApi.adoc
@@ -76,23 +76,23 @@ include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test
 
 ===== *Http Request*
 
-include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-supporter-runner-posts-by-runner-post-id/http-request.adoc[]
+include::{snippets}/../../build/generated-snippets/supporter-runner-post-read-api-test/read-supporter-runner-posts-by-runner-post-id/http-request.adoc[]
 
 ===== *Http Request Headers*
 
-include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-supporter-runner-posts-by-runner-post-id/request-headers.adoc[]
+include::{snippets}/../../build/generated-snippets/supporter-runner-post-read-api-test/read-supporter-runner-posts-by-runner-post-id/request-headers.adoc[]
 
 ===== *Http Request Path Parameters*
 
-include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-supporter-runner-posts-by-runner-post-id/path-parameters.adoc[]
+include::{snippets}/../../build/generated-snippets/supporter-runner-post-read-api-test/read-supporter-runner-posts-by-runner-post-id/path-parameters.adoc[]
 
 ===== *Http Response*
 
-include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-supporter-runner-posts-by-runner-post-id/http-response.adoc[]
+include::{snippets}/../../build/generated-snippets/supporter-runner-post-read-api-test/read-supporter-runner-posts-by-runner-post-id/http-response.adoc[]
 
 ===== *Http Response Fields*
 
-include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-supporter-runner-posts-by-runner-post-id/response-fields.adoc[]
+include::{snippets}/../../build/generated-snippets/supporter-runner-post-read-api-test/read-supporter-runner-posts-by-runner-post-id/response-fields.adoc[]
 
 ==== *서포터 마이페이지 러너 게시글 조회 API (queryParam)*
 

--- a/backend/baton/src/docs/asciidoc/RunnerPostUpdateApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerPostUpdateApi.adoc
@@ -10,9 +10,7 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-=== *러너 게시글 수정*
-
-==== *리뷰할 서포터 선택 API*
+==== *리뷰 할 서포터 선택 API*
 
 ===== *Http Request*
 
@@ -30,7 +28,7 @@ include::{snippets}/../../build/generated-snippets/runner-post-update-api-test/u
 
 include::{snippets}/../../build/generated-snippets/runner-post-update-api-test/update-runner-post-supporter/http-response.adoc[]
 
-==== *서포터 리뷰 완료 수정 API*
+==== *서포터가 러너 게시글을 리뷰 완료 상태로 변경 API*
 
 ===== *Http Request*
 

--- a/backend/baton/src/docs/asciidoc/RunnerPostUpdateApplicantCancelationApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerPostUpdateApplicantCancelationApi.adoc
@@ -10,7 +10,7 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-==== *서포터의 러너 게시글 리뷰 제안 철회 API*
+==== *서포터 러너 게시글 리뷰 제안 취소 API*
 
 ===== *Http Request*
 

--- a/backend/baton/src/docs/asciidoc/RunnerUpdateApi.adoc
+++ b/backend/baton/src/docs/asciidoc/RunnerUpdateApi.adoc
@@ -10,8 +10,6 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-=== *러너 프로필 수정*
-
 ==== *러너 프로필 수정 API*
 
 ===== *Http Request*

--- a/backend/baton/src/docs/asciidoc/SupporterReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/SupporterReadApi.adoc
@@ -47,38 +47,3 @@ include::{snippets}/../../build/generated-snippets/supporter-read-by-guest-api-t
 
 include::{snippets}/../../build/generated-snippets/supporter-read-by-guest-api-test/read-my-profile-by-token/response-fields.adoc[]
 
-==== *서포터 마이페이지 러너 게시글 조회 API (queryParam)*
-
-===== *Http Request*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-with-logined-supporter-api-test/read-runner-posts-by-logined-supporter-and-review-status/http-request.adoc[]
-
-===== *Http Request Query Parameters*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-with-logined-supporter-api-test/read-runner-posts-by-logined-supporter-and-review-status/query-parameters.adoc[]
-
-===== *Http Response*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-with-logined-supporter-api-test/read-runner-posts-by-logined-supporter-and-review-status/http-response.adoc[]
-
-===== *Http Response Fields*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-with-logined-supporter-api-test/read-runner-posts-by-logined-supporter-and-review-status/response-fields.adoc[]
-
-==== *서포터 리뷰 완료한 게시글 조회 API*
-
-===== *Http Request*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-referenced-by-supporter/http-request.adoc[]
-
-===== *Http Request Query Parameters*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-referenced-by-supporter/query-parameters.adoc[]
-
-===== *Http Response*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-referenced-by-supporter/http-response.adoc[]
-
-===== *Http Response Fields*
-
-include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-referenced-by-supporter/response-fields.adoc[]

--- a/backend/baton/src/docs/asciidoc/SupporterReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/SupporterReadApi.adoc
@@ -28,7 +28,6 @@ include::{snippets}/../../build/generated-snippets/supporter-read-by-guest-api-t
 
 include::{snippets}/../../build/generated-snippets/supporter-read-by-guest-api-test/read-profile-by-supporter-id/response-fields.adoc[]
 
-
 ==== *서포터 마이페이지 프로필 조회 API*
 
 ===== *Http Request*

--- a/backend/baton/src/docs/asciidoc/SupporterReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/SupporterReadApi.adoc
@@ -10,6 +10,25 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
+==== *서포터 프로필 조회 API*
+
+===== *Http Request*
+
+include::{snippets}/../../build/generated-snippets/supporter-read-by-guest-api-test/read-profile-by-supporter-id/http-request.adoc[]
+
+===== *Http Request Path Parameters*
+
+include::{snippets}/../../build/generated-snippets/supporter-read-by-guest-api-test/read-profile-by-supporter-id/path-parameters.adoc[]
+
+===== *Http Response*
+
+include::{snippets}/../../build/generated-snippets/supporter-read-by-guest-api-test/read-profile-by-supporter-id/http-response.adoc[]
+
+===== *Http Response Fields*
+
+include::{snippets}/../../build/generated-snippets/supporter-read-by-guest-api-test/read-profile-by-supporter-id/response-fields.adoc[]
+
+
 ==== *서포터 마이페이지 프로필 조회 API*
 
 ===== *Http Request*
@@ -32,18 +51,34 @@ include::{snippets}/../../build/generated-snippets/supporter-read-by-guest-api-t
 
 ===== *Http Request*
 
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-referenced-by-supporter/http-request.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-read-with-logined-supporter-api-test/read-runner-posts-by-logined-supporter-and-review-status/http-request.adoc[]
 
 ===== *Http Request Query Parameters*
 
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-referenced-by-supporter/query-parameters.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-read-with-logined-supporter-api-test/read-runner-posts-by-logined-supporter-and-review-status/query-parameters.adoc[]
 
 ===== *Http Response*
 
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-referenced-by-supporter/http-response.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-read-with-logined-supporter-api-test/read-runner-posts-by-logined-supporter-and-review-status/http-response.adoc[]
 
 ===== *Http Response Fields*
 
-include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-referenced-by-supporter/response-fields.adoc[]
+include::{snippets}/../../build/generated-snippets/runner-post-read-with-logined-supporter-api-test/read-runner-posts-by-logined-supporter-and-review-status/response-fields.adoc[]
 
+==== *서포터 리뷰 완료한 게시글 조회 API*
 
+===== *Http Request*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-referenced-by-supporter/http-request.adoc[]
+
+===== *Http Request Query Parameters*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-referenced-by-supporter/query-parameters.adoc[]
+
+===== *Http Response*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-referenced-by-supporter/http-response.adoc[]
+
+===== *Http Response Fields*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-of-supporter-by-guest-api-test/read-referenced-by-supporter/response-fields.adoc[]

--- a/backend/baton/src/docs/asciidoc/SupporterReadApi.adoc
+++ b/backend/baton/src/docs/asciidoc/SupporterReadApi.adoc
@@ -10,8 +10,6 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-=== *서포터 프로필 조회*
-
 ==== *서포터 마이페이지 프로필 조회 API*
 
 ===== *Http Request*
@@ -29,3 +27,23 @@ include::{snippets}/../../build/generated-snippets/supporter-read-by-guest-api-t
 ===== *Http Response Fields*
 
 include::{snippets}/../../build/generated-snippets/supporter-read-by-guest-api-test/read-my-profile-by-token/response-fields.adoc[]
+
+==== *서포터 마이페이지 러너 게시글 조회 API (queryParam)*
+
+===== *Http Request*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-referenced-by-supporter/http-request.adoc[]
+
+===== *Http Request Query Parameters*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-referenced-by-supporter/query-parameters.adoc[]
+
+===== *Http Response*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-referenced-by-supporter/http-response.adoc[]
+
+===== *Http Response Fields*
+
+include::{snippets}/../../build/generated-snippets/runner-post-read-all-api-test/read-referenced-by-supporter/response-fields.adoc[]
+
+

--- a/backend/baton/src/docs/asciidoc/SupporterUpdateApi.adoc
+++ b/backend/baton/src/docs/asciidoc/SupporterUpdateApi.adoc
@@ -10,8 +10,6 @@ endif::[]
 :operation-http-request-title: Example Request
 :operation-http-response-title: Example Response
 
-=== *서포터 프로필 수정*
-
 ==== *서포터 프로필 수정 API*
 
 ===== *Http Request*

--- a/backend/baton/src/docs/asciidoc/index.adoc
+++ b/backend/baton/src/docs/asciidoc/index.adoc
@@ -19,7 +19,6 @@ include::MemberLoginReadApi.adoc[]
 === *러너 프로필 조회*
 
 include::RunneReadApi.adoc[]
-include::RunnerLoginReadApi.adoc[]
 
 === *러너 프로필 수정*
 
@@ -28,6 +27,7 @@ include::RunnerUpdateApi.adoc[]
 === *서포터 프로필 조회*
 
 include::SupporterReadApi.adoc[]
+include::RunnerLoginReadApi.adoc[]
 
 === *서포터 프로필 수정*
 

--- a/backend/baton/src/docs/asciidoc/index.adoc
+++ b/backend/baton/src/docs/asciidoc/index.adoc
@@ -10,27 +10,45 @@ endif::[]
 
 = Baton-API
 
-== *[사용자(러너와 서포터 공통)]*
+== *[ 프로필 ]*
+
+=== *사용자 프로필 조회*
 
 include::MemberLoginReadApi.adoc[]
 
-== *[ 게시글 ]*
-
-include::RunnerPostCreateReadApi.adoc[]
-include::RunnerPostReadApi.adoc[]
-include::RunnerPostUpdateApi.adoc[]
-include::RunnerPostUpdateApplicantCancelationApi.adoc[]
-include::RunnerPostDeleteApi.adoc[]
-
-== *[ 러너 ]*
+=== *러너 프로필 조회*
 
 include::RunneReadApi.adoc[]
 include::RunnerLoginReadApi.adoc[]
-include::RunnerUpdateApi.adoc[]
-include::RunnerPostCreateApi.adoc[]
 
-== *[ 서포터 ]*
+=== *러너 프로필 수정*
+
+include::RunnerUpdateApi.adoc[]
+
+=== *서포터 프로필 조회*
 
 include::SupporterReadApi.adoc[]
+
+=== *서포터 프로필 수정*
+
 include::SupporterUpdateApi.adoc[]
+
+== *[ 러너 - 게시글 ]*
+
+=== *러너 게시글 생성*
+
+include::RunnerPostCreateApi.adoc[]
+
+=== *러너 게시글 조회*
+
+include::RunnerPostReadApi.adoc[]
+
+=== *러너 게시글 수정*
+
 include::RunnerPostUpdateApi.adoc[]
+include::RunnerPostCreateReadApi.adoc[]
+include::RunnerPostUpdateApplicantCancelationApi.adoc[]
+
+=== *러너 게시글 삭제*
+
+include::RunnerPostDeleteApi.adoc[]

--- a/backend/baton/src/test/java/touch/baton/document/runnerpost/read/RunnerPostReadAllApiTest.java
+++ b/backend/baton/src/test/java/touch/baton/document/runnerpost/read/RunnerPostReadAllApiTest.java
@@ -14,12 +14,10 @@ import touch.baton.domain.runnerpost.controller.RunnerPostController;
 import touch.baton.domain.runnerpost.service.RunnerPostService;
 import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
-import touch.baton.domain.supporter.Supporter;
 import touch.baton.domain.tag.Tag;
 import touch.baton.fixture.domain.MemberFixture;
 import touch.baton.fixture.domain.RunnerFixture;
 import touch.baton.fixture.domain.RunnerPostFixture;
-import touch.baton.fixture.domain.SupporterFixture;
 import touch.baton.fixture.domain.TagFixture;
 
 import java.time.LocalDateTime;
@@ -38,7 +36,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.head;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
@@ -49,10 +46,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static touch.baton.fixture.domain.TechnicalTagFixture.createJava;
-import static touch.baton.fixture.domain.TechnicalTagFixture.createSpring;
 import static touch.baton.fixture.vo.DeadlineFixture.deadline;
-import static touch.baton.fixture.vo.ReviewCountFixture.reviewCount;
 import static touch.baton.fixture.vo.TagNameFixture.tagName;
 
 @WebMvcTest(RunnerPostController.class)
@@ -113,68 +107,6 @@ class RunnerPostReadAllApiTest extends RestdocsConfig {
                                 fieldWithPath("pageInfo.totalElements").type(NUMBER).description("총 데이터 수"),
                                 fieldWithPath("pageInfo.currentPage").type(NUMBER).description("현재 페이지"),
                                 fieldWithPath("pageInfo.currentSize").type(NUMBER).description("현재 페이지 데이터 수")
-                        ))
-                );
-    }
-
-    @DisplayName("서포터와 연관된 러너 게시글 페이징 조회 API")
-    @Test
-    void readReferencedBySupporter() throws Exception {
-        // given
-        final Runner runnerJudy = RunnerFixture.createRunner(MemberFixture.createJudy());
-        final Supporter supporterHyena = SupporterFixture.create(reviewCount(10), MemberFixture.createHyena(), List.of(createJava(), createSpring()));
-
-        final Tag javaTag = TagFixture.create(tagName("자바"));
-        final Deadline deadline = deadline(LocalDateTime.now().plusHours(100));
-        final RunnerPost runnerPost = RunnerPostFixture.create(runnerJudy, deadline, List.of(javaTag));
-        runnerPost.assignSupporter(supporterHyena);
-
-        // when
-        final RunnerPost spyRunnerPost = spy(runnerPost);
-        final Supporter spySupporterHyena = spy(supporterHyena);
-        when(spySupporterHyena.getId()).thenReturn(1L);
-        when(spyRunnerPost.getId()).thenReturn(1L);
-
-        final List<RunnerPost> runnerPosts = List.of(spyRunnerPost);
-        final PageRequest pageOne = PageRequest.of(1, 10);
-        final PageImpl<RunnerPost> pageRunnerPosts = new PageImpl<>(runnerPosts, pageOne, runnerPosts.size());
-        when(runnerPostService.readRunnerPostsBySupporterIdAndReviewStatus(any(), any(), any()))
-                .thenReturn(pageRunnerPosts);
-        when(runnerPostService.readCountsByRunnerPostIds(anyList()))
-                .thenReturn(List.of(1L));
-
-        // then
-        mockMvc.perform(get("/api/v1/posts/runner/search")
-                        .characterEncoding(UTF_8)
-                        .contentType(APPLICATION_JSON)
-                        .queryParam("size", String.valueOf(pageOne.getPageSize()))
-                        .queryParam("page", String.valueOf(pageOne.getPageNumber()))
-                        .queryParam("supporterId", String.valueOf(spySupporterHyena.getId()))
-                        .queryParam("reviewStatus", ReviewStatus.IN_PROGRESS.name()))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(APPLICATION_JSON))
-                .andDo(restDocs.document(
-                        queryParameters(
-                                parameterWithName("size").description("페이지 사이즈"),
-                                parameterWithName("page").description("페이지 번호"),
-                                parameterWithName("supporterId").description("서포터 식별자값"),
-                                parameterWithName("reviewStatus").description("리뷰 상태")
-                        ),
-                        responseFields(
-                                fieldWithPath("pageInfo.isFirst").type(BOOLEAN).description("첫 번째 페이지인지"),
-                                fieldWithPath("pageInfo.isLast").type(BOOLEAN).description("마지막 페이지 인지"),
-                                fieldWithPath("pageInfo.hasNext").type(BOOLEAN).description("다음 페이지가 있는지"),
-                                fieldWithPath("pageInfo.totalPages").type(NUMBER).description("총 페이지 수"),
-                                fieldWithPath("pageInfo.totalElements").type(NUMBER).description("총 데이터 수"),
-                                fieldWithPath("pageInfo.currentPage").type(NUMBER).description("현재 페이지 번호"),
-                                fieldWithPath("pageInfo.currentSize").type(NUMBER).description("현재 페이지 데이터 수"),
-                                fieldWithPath("data.[].runnerPostId").type(NUMBER).description("러너 게시글 식별자값(id)"),
-                                fieldWithPath("data.[].title").type(STRING).description("러너 게시글 제목"),
-                                fieldWithPath("data.[].deadline").type(STRING).description("러너 게시글의 마감 기한"),
-                                fieldWithPath("data.[].tags").type(ARRAY).description("러너 게시글 태그 목록"),
-                                fieldWithPath("data.[].watchedCount").type(NUMBER).description("러너 게시글의 조회수"),
-                                fieldWithPath("data.[].applicantCount").type(NUMBER).description("러너 게시글에 신청한 서포터 수"),
-                                fieldWithPath("data.[].reviewStatus").type(STRING).description("러너 게시글 리뷰 상태")
                         ))
                 );
     }


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #409 

## 참고사항
- index.adoc을 노션 목차에 맞게 변경했습니다.
- 목차를 나누기 쉽지 않아서 index.adoc에서 api 소제목을 관리하고 api 이름은 각각의 include된 adoc 파일에서 작성하게 변경했습니다.