### PR TITLE
데이터베이스 컬럼과 entity 컬럼의 이름과 순서를 일치하게 변경

### DIFF
--- a/backend/baton/src/main/java/touch/baton/domain/common/vo/WatchedCount.java
+++ b/backend/baton/src/main/java/touch/baton/domain/common/vo/WatchedCount.java
@@ -18,7 +18,7 @@ public class WatchedCount {
     private static final String DEFAULT_VALUE = "0";
 
     @ColumnDefault(DEFAULT_VALUE)
-    @Column(name = "watch_count", nullable = false)
+    @Column(name = "watched_count", nullable = false)
     private int value;
 
     public WatchedCount(final int value) {

--- a/backend/baton/src/main/java/touch/baton/domain/tag/RunnerPostTag.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/RunnerPostTag.java
@@ -34,7 +34,7 @@ public class RunnerPostTag {
     private RunnerPost runnerPost;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "post_tag_id", nullable = false, foreignKey = @ForeignKey(name = "fk_runner_post_tag_to_tag"))
+    @JoinColumn(name = "tag_id", nullable = false, foreignKey = @ForeignKey(name = "fk_runner_post_tag_to_tag"))
     private Tag tag;
 
     @Builder

--- a/backend/baton/src/main/java/touch/baton/domain/tag/RunnerPostTag.java
+++ b/backend/baton/src/main/java/touch/baton/domain/tag/RunnerPostTag.java
@@ -34,7 +34,7 @@ public class RunnerPostTag {
     private RunnerPost runnerPost;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "tag_id", nullable = false, foreignKey = @ForeignKey(name = "fk_runner_post_tag_to_tag"))
+    @JoinColumn(name = "post_tag_id", nullable = false, foreignKey = @ForeignKey(name = "fk_runner_post_tag_to_tag"))
     private Tag tag;
 
     @Builder


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #439 

## 참고사항
- dev, deploy 데이터베이스의 순서를 erd와 일치시켰습니다.
- runner_post 테이블의 watch_count -> watched_count
	- 머지할 때 database를 변경해야합니다.(dev, deploy 둘 다)
	