### PR TITLE
게시글 정렬 시 createdAt 이 같다면 id 오름차순으로 정렬되게 보여주는 기능 추가

### DIFF
--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/RunnerPostController.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/RunnerPostController.java
@@ -89,7 +89,7 @@ public class RunnerPostController {
 
     @GetMapping
     public ResponseEntity<PageResponse<RunnerPostResponse.Simple>> readRunnerPostsByReviewStatus(
-            @PageableDefault(sort = "createdAt", direction = DESC) final Pageable pageable,
+            @PageableDefault(sort = {"createdAt", "id"}, direction = DESC) final Pageable pageable,
             @RequestParam("reviewStatus") final ReviewStatus reviewStatus
     ) {
         final Page<RunnerPost> pageRunnerPosts = runnerPostService.readRunnerPostsByReviewStatus(pageable, reviewStatus);
@@ -111,7 +111,7 @@ public class RunnerPostController {
 
     @GetMapping("/search")
     public ResponseEntity<PageResponse<RunnerPostResponse.ReferencedBySupporter>> readReferencedBySupporter(
-            @PageableDefault(sort = "createdAt", direction = DESC) final Pageable pageable,
+            @PageableDefault(sort = {"createdAt", "id"}, direction = DESC) final Pageable pageable,
             @RequestParam("supporterId") final Long supporterId,
             @RequestParam("reviewStatus") final ReviewStatus reviewStatus
     ) {
@@ -146,7 +146,7 @@ public class RunnerPostController {
 
     @GetMapping("/me/supporter")
     public ResponseEntity<PageResponse<RunnerPostResponse.ReferencedBySupporter>> readRunnerPostsByLoginedSupporterAndReviewStatus(
-            @PageableDefault(sort = "createdAt", direction = DESC) final Pageable pageable,
+            @PageableDefault(sort = {"createdAt", "id"}, direction = DESC) final Pageable pageable,
             @AuthSupporterPrincipal final Supporter supporter,
             @RequestParam("reviewStatus") final ReviewStatus reviewStatus
     ) {
@@ -169,7 +169,7 @@ public class RunnerPostController {
 
     @GetMapping("/me/runner")
     public ResponseEntity<PageResponse<RunnerPostResponse.SimpleInMyPage>> readRunnerMyPage(
-            @PageableDefault(sort = "createdAt", direction = DESC) final Pageable pageable,
+            @PageableDefault(sort = {"createdAt", "id"}, direction = DESC) final Pageable pageable,
             @AuthRunnerPrincipal final Runner runner,
             @RequestParam("reviewStatus") final ReviewStatus reviewStatus
     ) {

--- a/backend/baton/src/test/java/touch/baton/domain/oauth/repository/RefreshTokenRepositoryTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/oauth/repository/RefreshTokenRepositoryTest.java
@@ -1,7 +1,6 @@
 package touch.baton.domain.oauth.repository;
 
 import jakarta.persistence.EntityManager;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,13 +12,13 @@ import touch.baton.fixture.domain.MemberFixture;
 import touch.baton.fixture.domain.RefreshTokenFixture;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static touch.baton.fixture.vo.ExpireDateFixture.expireDate;
 import static touch.baton.fixture.vo.TokenFixture.token;
+import static touch.baton.util.TestDateFormatUtil.createExpireDate;
 
 class RefreshTokenRepositoryTest extends RepositoryTestConfig {
 
@@ -89,13 +88,5 @@ class RefreshTokenRepositoryTest extends RepositoryTestConfig {
             softly.assertThat(actual.get().getToken()).isEqualTo(expected.getToken());
             softly.assertThat(actual.get().getExpireDate()).isEqualTo(expected.getExpireDate());
         } );
-    }
-
-    @NotNull
-    private static LocalDateTime createExpireDate(final LocalDateTime expireDate) {
-        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
-        final String formattedExpireDate = expireDate.format(formatter);
-
-        return LocalDateTime.parse(formattedExpireDate, formatter);
     }
 }

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/read/RunnerPostRepositoryReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/read/RunnerPostRepositoryReadTest.java
@@ -4,6 +4,9 @@ import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import touch.baton.config.RepositoryTestConfig;
 import touch.baton.domain.member.Member;
 import touch.baton.domain.member.repository.MemberRepository;
@@ -26,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static touch.baton.domain.runnerpost.vo.ReviewStatus.NOT_STARTED;
 import static touch.baton.fixture.domain.RunnerPostTagsFixture.runnerPostTags;
 import static touch.baton.fixture.vo.CuriousContentsFixture.curiousContents;
@@ -54,16 +58,16 @@ class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
     private RunnerPostTagRepository runnerPostTagRepository;
 
     @Autowired
-    private EntityManager entityManager;
+    private EntityManager em;
 
     @DisplayName("RunnerPost 식별자로 RunnerPostTag 목록을 조회할 때 Tag 가 있으면 조회된다.")
     @Test
     void findRunnerPostTagsById_exist() {
         // given
         final Member ditoo = MemberFixture.createDitoo();
-        entityManager.persist(ditoo);
+        em.persist(ditoo);
         final Runner runner = RunnerFixture.createRunner(ditoo);
-        entityManager.persist(runner);
+        em.persist(runner);
 
         final RunnerPost runnerPost = RunnerPostFixture.create(title("제 코드를 리뷰해주세요"),
                 implementedContents("제 코드의 내용은 이렇습니다."),
@@ -79,9 +83,9 @@ class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
         runnerPostRepository.save(runnerPost);
 
         final Tag java = TagFixture.createJava();
-        entityManager.persist(java);
+        em.persist(java);
         final Tag spring = TagFixture.createSpring();
-        entityManager.persist(spring);
+        em.persist(spring);
         final RunnerPostTag javaRunnerPostTag = RunnerPostTagFixture.create(runnerPost, java);
         final RunnerPostTag springRunnerPostTag = RunnerPostTagFixture.create(runnerPost, spring);
 
@@ -99,9 +103,9 @@ class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
     void findByRunnerId() {
         // given
         final Member ditoo = MemberFixture.createDitoo();
-        entityManager.persist(ditoo);
+        em.persist(ditoo);
         final Runner runner = RunnerFixture.createRunner(ditoo);
-        entityManager.persist(runner);
+        em.persist(runner);
 
         final RunnerPost runnerPost = RunnerPostFixture.create(title("제 코드를 리뷰해주세요"),
                 implementedContents("제 코드의 내용은 이렇습니다."),
@@ -121,5 +125,91 @@ class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
 
         // then
         assertThat(actual).containsExactly(runnerPost);
+    }
+
+    @DisplayName("생성 시간이 같다면 다음 기준인 id 오름차순으로 게시글 페이징 조회한다")
+    @Test
+    void findByReviewStatus_when_createAt_is_same() {
+        // given
+        final Member ditoo = MemberFixture.createDitoo();
+        em.persist(ditoo);
+        final Runner runner = RunnerFixture.createRunner(ditoo);
+        em.persist(runner);
+        final Long runnerId = runner.getId();
+        final LocalDateTime createdAt = LocalDateTime.now();
+
+        em.createNativeQuery("""
+                        insert into runner_post (id, title, implemented_contents, curious_contents, postscript_contents, 
+                            pull_request_url, deadline, review_status, created_at, updated_at, runner_id)
+                        values (:id, :title, :implemented_contents, :curious_contents, :postscript_contents, 
+                            :pull_request_url, :deadline, :review_status, :created_at, :updated_at, :runner_id)
+                        """)
+                .setParameter("id", 1L)
+                .setParameter("title", "제목1")
+                .setParameter("implemented_contents", "구현 내용1")
+                .setParameter("curious_contents", "궁금한 내용1")
+                .setParameter("postscript_contents", "참고 사항1")
+                .setParameter("pull_request_url", "pr url1")
+                .setParameter("deadline", LocalDateTime.now().plusHours(100))
+                .setParameter("review_status", NOT_STARTED.name())
+                .setParameter("created_at", createdAt)
+                .setParameter("updated_at", createdAt)
+                .setParameter("runner_id", runnerId)
+                .executeUpdate();
+
+        em.createNativeQuery("""
+                        insert into runner_post (id, title, implemented_contents, curious_contents, postscript_contents, 
+                            pull_request_url, deadline, review_status, created_at, updated_at, runner_id)
+                        values (:id, :title, :implemented_contents, :curious_contents, :postscript_contents, 
+                            :pull_request_url, :deadline, :review_status, :created_at, :updated_at, :runner_id)
+                        """)
+                .setParameter("id", 3L)
+                .setParameter("title", "제목3")
+                .setParameter("implemented_contents", "구현 내용3")
+                .setParameter("curious_contents", "궁금한 내용3")
+                .setParameter("postscript_contents", "참고 사항3")
+                .setParameter("pull_request_url", "pr url3")
+                .setParameter("deadline", LocalDateTime.now().plusHours(100))
+                .setParameter("review_status", NOT_STARTED.name())
+                .setParameter("created_at", createdAt)
+                .setParameter("updated_at", createdAt)
+                .setParameter("runner_id", runnerId)
+                .executeUpdate();
+
+        em.createNativeQuery("""
+                        insert into runner_post (id, title, implemented_contents, curious_contents, postscript_contents, 
+                            pull_request_url, deadline, review_status, created_at, updated_at, runner_id)
+                        values (:id, :title, :implemented_contents, :curious_contents, :postscript_contents, 
+                            :pull_request_url, :deadline, :review_status, :created_at, :updated_at, :runner_id)
+                        """)
+                .setParameter("id", 2L)
+                .setParameter("title", "제목2")
+                .setParameter("implemented_contents", "구현 내용2")
+                .setParameter("curious_contents", "궁금한 내용2")
+                .setParameter("postscript_contents", "참고 사항2")
+                .setParameter("pull_request_url", "pr url2")
+                .setParameter("deadline", LocalDateTime.now().plusHours(100))
+                .setParameter("review_status", NOT_STARTED.name())
+                .setParameter("created_at", createdAt)
+                .setParameter("updated_at", createdAt)
+                .setParameter("runner_id", runnerId)
+                .executeUpdate();
+
+        // when
+        final PageRequest pageable = PageRequest.of(0, 10, Sort.by(
+                Sort.Order.desc("createdAt"),
+                Sort.Order.desc("id")
+        ));
+        final Page<RunnerPost> actual = runnerPostRepository.findByReviewStatus(pageable, NOT_STARTED);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(actual.getTotalElements()).isEqualTo(3);
+
+            List<RunnerPost> contents = actual.getContent();
+            softly.assertThat(contents.get(0).getId()).isEqualTo(3L);
+            softly.assertThat(contents.get(1).getId()).isEqualTo(2L);
+            softly.assertThat(contents.get(2).getId()).isEqualTo(1L);
+        });
     }
 }

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/read/RunnerPostRepositoryReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/read/RunnerPostRepositoryReadTest.java
@@ -138,62 +138,9 @@ class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
         final Long runnerId = runner.getId();
         final LocalDateTime createdAt = LocalDateTime.now();
 
-        em.createNativeQuery("""
-                        insert into runner_post (id, title, implemented_contents, curious_contents, postscript_contents, 
-                            pull_request_url, deadline, review_status, created_at, updated_at, runner_id)
-                        values (:id, :title, :implemented_contents, :curious_contents, :postscript_contents, 
-                            :pull_request_url, :deadline, :review_status, :created_at, :updated_at, :runner_id)
-                        """)
-                .setParameter("id", 1L)
-                .setParameter("title", "제목1")
-                .setParameter("implemented_contents", "구현 내용1")
-                .setParameter("curious_contents", "궁금한 내용1")
-                .setParameter("postscript_contents", "참고 사항1")
-                .setParameter("pull_request_url", "pr url1")
-                .setParameter("deadline", LocalDateTime.now().plusHours(100))
-                .setParameter("review_status", NOT_STARTED.name())
-                .setParameter("created_at", createdAt)
-                .setParameter("updated_at", createdAt)
-                .setParameter("runner_id", runnerId)
-                .executeUpdate();
-
-        em.createNativeQuery("""
-                        insert into runner_post (id, title, implemented_contents, curious_contents, postscript_contents, 
-                            pull_request_url, deadline, review_status, created_at, updated_at, runner_id)
-                        values (:id, :title, :implemented_contents, :curious_contents, :postscript_contents, 
-                            :pull_request_url, :deadline, :review_status, :created_at, :updated_at, :runner_id)
-                        """)
-                .setParameter("id", 3L)
-                .setParameter("title", "제목3")
-                .setParameter("implemented_contents", "구현 내용3")
-                .setParameter("curious_contents", "궁금한 내용3")
-                .setParameter("postscript_contents", "참고 사항3")
-                .setParameter("pull_request_url", "pr url3")
-                .setParameter("deadline", LocalDateTime.now().plusHours(100))
-                .setParameter("review_status", NOT_STARTED.name())
-                .setParameter("created_at", createdAt)
-                .setParameter("updated_at", createdAt)
-                .setParameter("runner_id", runnerId)
-                .executeUpdate();
-
-        em.createNativeQuery("""
-                        insert into runner_post (id, title, implemented_contents, curious_contents, postscript_contents, 
-                            pull_request_url, deadline, review_status, created_at, updated_at, runner_id)
-                        values (:id, :title, :implemented_contents, :curious_contents, :postscript_contents, 
-                            :pull_request_url, :deadline, :review_status, :created_at, :updated_at, :runner_id)
-                        """)
-                .setParameter("id", 2L)
-                .setParameter("title", "제목2")
-                .setParameter("implemented_contents", "구현 내용2")
-                .setParameter("curious_contents", "궁금한 내용2")
-                .setParameter("postscript_contents", "참고 사항2")
-                .setParameter("pull_request_url", "pr url2")
-                .setParameter("deadline", LocalDateTime.now().plusHours(100))
-                .setParameter("review_status", NOT_STARTED.name())
-                .setParameter("created_at", createdAt)
-                .setParameter("updated_at", createdAt)
-                .setParameter("runner_id", runnerId)
-                .executeUpdate();
+        insertRunnerPostByNativeQuery(1L, createdAt, runnerId);
+        insertRunnerPostByNativeQuery(3L, createdAt, runnerId);
+        insertRunnerPostByNativeQuery(2L, createdAt, runnerId);
 
         // when
         final PageRequest pageable = PageRequest.of(0, 10, Sort.by(
@@ -206,10 +153,35 @@ class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
         assertSoftly(softly -> {
             softly.assertThat(actual.getTotalElements()).isEqualTo(3);
 
-            List<RunnerPost> contents = actual.getContent();
-            softly.assertThat(contents.get(0).getId()).isEqualTo(3L);
-            softly.assertThat(contents.get(1).getId()).isEqualTo(2L);
-            softly.assertThat(contents.get(2).getId()).isEqualTo(1L);
+            List<RunnerPost> runnerPosts = actual.getContent();
+            softly.assertThat(runnerPosts.get(0).getId()).isEqualTo(3L);
+            softly.assertThat(runnerPosts.get(1).getId()).isEqualTo(2L);
+            softly.assertThat(runnerPosts.get(2).getId()).isEqualTo(1L);
+
+            softly.assertThat(runnerPosts.stream()
+                    .filter(runnerPost -> runnerPost.getCreatedAt().isEqual(createdAt))
+                    .count()).isEqualTo(3);
         });
+    }
+
+    private void insertRunnerPostByNativeQuery(final long value, final LocalDateTime createdAt, final Long runnerId) {
+        em.createNativeQuery("""
+                        insert into runner_post (id, title, implemented_contents, curious_contents, postscript_contents, 
+                            pull_request_url, deadline, review_status, created_at, updated_at, runner_id)
+                        values (:id, :title, :implemented_contents, :curious_contents, :postscript_contents, 
+                            :pull_request_url, :deadline, :review_status, :created_at, :updated_at, :runner_id)
+                        """)
+                .setParameter("id", value)
+                .setParameter("title", "제목")
+                .setParameter("implemented_contents", "구현 내용")
+                .setParameter("curious_contents", "궁금한 내용")
+                .setParameter("postscript_contents", "참고 사항")
+                .setParameter("pull_request_url", "pr url")
+                .setParameter("deadline", LocalDateTime.now().plusHours(100))
+                .setParameter("review_status", NOT_STARTED.name())
+                .setParameter("created_at", createdAt)
+                .setParameter("updated_at", createdAt)
+                .setParameter("runner_id", runnerId)
+                .executeUpdate();
     }
 }

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/read/RunnerPostRepositoryReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/read/RunnerPostRepositoryReadTest.java
@@ -39,6 +39,7 @@ import static touch.baton.fixture.vo.PostscriptContentsFixture.postscriptContent
 import static touch.baton.fixture.vo.PullRequestUrlFixture.pullRequestUrl;
 import static touch.baton.fixture.vo.TitleFixture.title;
 import static touch.baton.fixture.vo.WatchedCountFixture.watchedCount;
+import static touch.baton.util.TestDateFormatUtil.createExpireDate;
 
 class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
 
@@ -136,7 +137,7 @@ class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
         final Runner runner = RunnerFixture.createRunner(ditoo);
         em.persist(runner);
         final Long runnerId = runner.getId();
-        final LocalDateTime createdAt = LocalDateTime.now();
+        final LocalDateTime createdAt = createExpireDate(LocalDateTime.now());
 
         insertRunnerPostByNativeQuery(1L, createdAt, runnerId);
         insertRunnerPostByNativeQuery(3L, createdAt, runnerId);

--- a/backend/baton/src/test/java/touch/baton/util/TestDateFormatUtil.java
+++ b/backend/baton/src/test/java/touch/baton/util/TestDateFormatUtil.java
@@ -1,0 +1,14 @@
+package touch.baton.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class TestDateFormatUtil {
+
+    public static LocalDateTime createExpireDate(final LocalDateTime expireDate) {
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
+        final String formattedExpireDate = expireDate.format(formatter);
+
+        return LocalDateTime.parse(formattedExpireDate, formatter);
+    }
+}


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #481 

## 참고사항
레포 테스트로만 진행했습니다.
결국 확인하고 싶은 것은 "정렬이 잘 되냐?" 이기 때문에 서비스나 컨트롤러 테스트를 진행하지 않았습니다.
Pageable 테스트이긴 한데 레포지토리에서 정렬된 값을 만들어 반환하기 때문에 가장 앞단인 레포지토리 테스트만 진행했습니다.
