### PR TITLE
api 에러시 보여주는 문구 변경

### DIFF
--- a/frontend/src/hooks/useFetch.ts
+++ b/frontend/src/hooks/useFetch.ts
@@ -31,10 +31,10 @@ export const useFetch = () => {
 
         return response;
       })
-      .catch((error) => {
+      .catch(() => {
         showErrorToast({
-          title: ERROR_TITLE.NETWORK,
-          description: error instanceof Error ? error.message : ERROR_DESCRIPTION.UNEXPECTED,
+          title: ERROR_TITLE.ERROR,
+          description: ERROR_DESCRIPTION.UNEXPECTED,
         });
       });
 


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #520 

## 참고사항
- `fetchAPI` 에서 errorCode가 없을 경우 기본 message 대신 '예기치 못한 오류' 로 변경

기존
<img width="624" alt="image" src="https://github.com/woowacourse-teams/2023-baton/assets/116625502/03d28b98-c4c1-4f6d-9292-63bbfd10e85a">

변경 후
<img width="561" alt="image" src="https://github.com/woowacourse-teams/2023-baton/assets/116625502/7c0b5e01-0518-442e-b964-f80e7d0cc2ec">