### PR TITLE
서포터 피드백 작성 유무 반환 추가, 러너 게시글 조회수 flyway 컬럼명 수정, 서포터 지원자 수 조회시 dto 사용하도록 수정

### DIFF
--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/RunnerPost.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/RunnerPost.java
@@ -21,6 +21,7 @@ import touch.baton.domain.runnerpost.exception.RunnerPostDomainException;
 import touch.baton.domain.runnerpost.vo.CuriousContents;
 import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.ImplementedContents;
+import touch.baton.domain.runnerpost.vo.IsReviewed;
 import touch.baton.domain.runnerpost.vo.PostscriptContents;
 import touch.baton.domain.runnerpost.vo.PullRequestUrl;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
@@ -37,7 +38,10 @@ import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
-import static touch.baton.domain.runnerpost.vo.ReviewStatus.*;
+import static touch.baton.domain.runnerpost.vo.ReviewStatus.DONE;
+import static touch.baton.domain.runnerpost.vo.ReviewStatus.IN_PROGRESS;
+import static touch.baton.domain.runnerpost.vo.ReviewStatus.NOT_STARTED;
+import static touch.baton.domain.runnerpost.vo.ReviewStatus.OVERDUE;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
@@ -73,6 +77,9 @@ public class RunnerPost extends BaseEntity {
     @Column(nullable = false)
     private ReviewStatus reviewStatus = ReviewStatus.NOT_STARTED;
 
+    @Embedded
+    private IsReviewed isReviewed;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "runner_id", foreignKey = @ForeignKey(name = "fk_runner_post_to_runner"), nullable = false)
     private Runner runner;
@@ -93,11 +100,12 @@ public class RunnerPost extends BaseEntity {
                        final Deadline deadline,
                        final WatchedCount watchedCount,
                        final ReviewStatus reviewStatus,
+                       final IsReviewed isReviewed,
                        final Runner runner,
                        final Supporter supporter,
                        final RunnerPostTags runnerPostTags
     ) {
-        this(null, title, implementedContents, curiousContents, postscriptContents, pullRequestUrl, deadline, watchedCount, reviewStatus, runner, supporter, runnerPostTags);
+        this(null, title, implementedContents, curiousContents, postscriptContents, pullRequestUrl, deadline, watchedCount, reviewStatus, isReviewed, runner, supporter, runnerPostTags);
     }
 
     private RunnerPost(final Long id,
@@ -109,11 +117,12 @@ public class RunnerPost extends BaseEntity {
                        final Deadline deadline,
                        final WatchedCount watchedCount,
                        final ReviewStatus reviewStatus,
+                       final IsReviewed isReviewed,
                        final Runner runner,
                        final Supporter supporter,
                        final RunnerPostTags runnerPostTags
     ) {
-        validateNotNull(title, implementedContents, curiousContents, postscriptContents, pullRequestUrl, deadline, watchedCount, reviewStatus, runner, runnerPostTags);
+        validateNotNull(title, implementedContents, curiousContents, postscriptContents, pullRequestUrl, deadline, watchedCount, reviewStatus, isReviewed, runner, runnerPostTags);
         this.id = id;
         this.title = title;
         this.implementedContents = implementedContents;
@@ -123,6 +132,7 @@ public class RunnerPost extends BaseEntity {
         this.deadline = deadline;
         this.watchedCount = watchedCount;
         this.reviewStatus = reviewStatus;
+        this.isReviewed = isReviewed;
         this.runner = runner;
         this.supporter = supporter;
         this.runnerPostTags = runnerPostTags;
@@ -143,10 +153,11 @@ public class RunnerPost extends BaseEntity {
                 .postscriptContents(new PostscriptContents(postscriptContents))
                 .pullRequestUrl(new PullRequestUrl(pullRequestUrl))
                 .deadline(new Deadline(deadline))
-                .runner(runner)
-                .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
                 .watchedCount(WatchedCount.zero())
                 .reviewStatus(NOT_STARTED)
+                .isReviewed(IsReviewed.notReviewed())
+                .runner(runner)
+                .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
                 .build();
     }
 
@@ -158,6 +169,7 @@ public class RunnerPost extends BaseEntity {
                                  final Deadline deadline,
                                  final WatchedCount watchedCount,
                                  final ReviewStatus reviewStatus,
+                                 final IsReviewed isReviewed,
                                  final Runner runner,
                                  final RunnerPostTags runnerPostTags
     ) {
@@ -184,6 +196,9 @@ public class RunnerPost extends BaseEntity {
         }
         if (Objects.isNull(reviewStatus)) {
             throw new RunnerPostDomainException("RunnerPost 의 reviewStatus 는 null 일 수 없습니다.");
+        }
+        if (Objects.isNull(isReviewed)) {
+            throw new RunnerPostDomainException("RunnerPost 의 isReviewed 는 null 일 수 없습니다.");
         }
         if (Objects.isNull(runner)) {
             throw new RunnerPostDomainException("RunnerPost 의 runner 는 null 일 수 없습니다.");

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/response/RunnerPostResponse.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/response/RunnerPostResponse.java
@@ -114,6 +114,7 @@ public record RunnerPostResponse() {
             );
         }
     }
+
     public record SimpleInMyPage(Long runnerPostId,
                                  Long supporterId,
                                  String title,
@@ -121,7 +122,8 @@ public record RunnerPostResponse() {
                                  List<String> tags,
                                  int watchedCount,
                                  long applicantCount,
-                                 String reviewStatus
+                                 String reviewStatus,
+                                 boolean isReviewed
 
     ) {
 
@@ -136,7 +138,8 @@ public record RunnerPostResponse() {
                     convertToTags(runnerPost),
                     runnerPost.getWatchedCount().getValue(),
                     applicantCount,
-                    runnerPost.getReviewStatus().name()
+                    runnerPost.getReviewStatus().name(),
+                     runnerPost.getIsReviewed().isValue()
             );
         }
 

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/response/RunnerPostResponse.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/response/RunnerPostResponse.java
@@ -139,7 +139,7 @@ public record RunnerPostResponse() {
                     runnerPost.getWatchedCount().getValue(),
                     applicantCount,
                     runnerPost.getReviewStatus().name(),
-                     runnerPost.getIsReviewed().isValue()
+                     runnerPost.getIsReviewed().getValue()
             );
         }
 

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/response/RunnerPostResponse.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/controller/response/RunnerPostResponse.java
@@ -139,7 +139,7 @@ public record RunnerPostResponse() {
                     runnerPost.getWatchedCount().getValue(),
                     applicantCount,
                     runnerPost.getReviewStatus().name(),
-                     runnerPost.getIsReviewed().getValue()
+                    runnerPost.getIsReviewed().getValue()
             );
         }
 

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/RunnerPostReadRepository.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/RunnerPostReadRepository.java
@@ -21,8 +21,8 @@ public interface RunnerPostReadRepository extends JpaRepository<RunnerPost, Long
         final Map<Long, Long> applicantCountMapping = countApplicantsByRunnerPostIds(runnerPostIds)
                 .stream()
                 .collect(Collectors.toMap(
-                        applicantCountDto -> applicantCountDto.getRunnerPostId(),
-                        applicantCountDto -> applicantCountDto.getApplicantCount()
+                        ApplicantCountDto::runnerPostId,
+                        ApplicantCountDto::applicantCount
                 ));
 
         return new ApplicantCountMappingDto(applicantCountMapping);
@@ -34,7 +34,6 @@ public interface RunnerPostReadRepository extends JpaRepository<RunnerPost, Long
             left outer join fetch SupporterRunnerPost srp on srp.runnerPost.id = rp.id
             where rp.id in :runnerPostIds
             group by rp.id
-            order by rp.id
             """)
     List<ApplicantCountDto> countApplicantsByRunnerPostIds(@Param("runnerPostIds") final List<Long> runnerPostIds);
 

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/RunnerPostReadRepository.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/RunnerPostReadRepository.java
@@ -6,21 +6,37 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import touch.baton.domain.runnerpost.RunnerPost;
+import touch.baton.domain.runnerpost.repository.dto.ApplicantCountDto;
+import touch.baton.domain.runnerpost.repository.dto.ApplicantCountMappingDto;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
 import touch.baton.domain.tag.vo.TagReducedName;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public interface RunnerPostReadRepository extends JpaRepository<RunnerPost, Long> {
 
-    @Query("""
-            select coalesce(count(srp.id), 0) 
+    default ApplicantCountMappingDto findApplicantCountMappingByRunnerPostIds(final List<Long> runnerPostIds) {
+        final Map<Long, Long> applicantCountMapping = countApplicantsByRunnerPostIds(runnerPostIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        applicantCountDto -> applicantCountDto.getRunnerPostId(),
+                        applicantCountDto -> applicantCountDto.getApplicantCount()
+                ));
+
+        return new ApplicantCountMappingDto(applicantCountMapping);
+    }
+
+    @Query(value = """
+            select new touch.baton.domain.runnerpost.repository.dto.ApplicantCountDto(rp.id, count(srp.id)) 
             from RunnerPost rp
             left outer join fetch SupporterRunnerPost srp on srp.runnerPost.id = rp.id
             where rp.id in :runnerPostIds
             group by rp.id
+            order by rp.id
             """)
-    List<Long> countApplicantsByRunnerPostIds(@Param("runnerPostIds") final List<Long> runnerPostIds);
+    List<ApplicantCountDto> countApplicantsByRunnerPostIds(@Param("runnerPostIds") final List<Long> runnerPostIds);
 
     @Query("""
             select rp
@@ -28,7 +44,7 @@ public interface RunnerPostReadRepository extends JpaRepository<RunnerPost, Long
             join fetch Runner r on r.id = rp.runner.id
             join fetch Member m on m.id = r.member.id
             join fetch RunnerPostTag rpt on rpt.runnerPost.id = rp.id
-            
+                        
             where rpt.tag.tagReducedName = :tagReducedName
             and rp.reviewStatus = :reviewStatus
             """)

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/RunnerPostReadRepository.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/RunnerPostReadRepository.java
@@ -44,7 +44,6 @@ public interface RunnerPostReadRepository extends JpaRepository<RunnerPost, Long
             join fetch Runner r on r.id = rp.runner.id
             join fetch Member m on m.id = r.member.id
             join fetch RunnerPostTag rpt on rpt.runnerPost.id = rp.id
-                        
             where rpt.tag.tagReducedName = :tagReducedName
             and rp.reviewStatus = :reviewStatus
             """)

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/dto/ApplicantCountDto.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/dto/ApplicantCountDto.java
@@ -36,12 +36,4 @@ public class ApplicantCountDto {
     public int hashCode() {
         return Objects.hash(runnerPostId, applicantCount);
     }
-
-    @Override
-    public String toString() {
-        return "ApplicantCountDto{" +
-               "runnerPostId=" + runnerPostId +
-               ", applicantCount=" + applicantCount +
-               '}';
-    }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/dto/ApplicantCountDto.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/dto/ApplicantCountDto.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 public class ApplicantCountDto {
 
     private Long runnerPostId;
+
     private Long applicantCount;
 
     public ApplicantCountDto() {

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/dto/ApplicantCountDto.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/dto/ApplicantCountDto.java
@@ -1,0 +1,46 @@
+package touch.baton.domain.runnerpost.repository.dto;
+
+import java.util.Objects;
+
+public class ApplicantCountDto {
+
+    private Long runnerPostId;
+    private Long applicantCount;
+
+    public ApplicantCountDto() {
+    }
+
+    public ApplicantCountDto(final Long runnerPostId, final Long applicantCount) {
+        this.runnerPostId = runnerPostId;
+        this.applicantCount = (long) applicantCount;
+    }
+
+    public Long getRunnerPostId() {
+        return runnerPostId;
+    }
+
+    public Long getApplicantCount() {
+        return applicantCount;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final ApplicantCountDto that = (ApplicantCountDto) o;
+        return applicantCount == that.applicantCount && Objects.equals(runnerPostId, that.runnerPostId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(runnerPostId, applicantCount);
+    }
+
+    @Override
+    public String toString() {
+        return "ApplicantCountDto{" +
+               "runnerPostId=" + runnerPostId +
+               ", applicantCount=" + applicantCount +
+               '}';
+    }
+}

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/dto/ApplicantCountDto.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/dto/ApplicantCountDto.java
@@ -1,39 +1,4 @@
 package touch.baton.domain.runnerpost.repository.dto;
 
-import java.util.Objects;
-
-public class ApplicantCountDto {
-
-    private Long runnerPostId;
-
-    private Long applicantCount;
-
-    public ApplicantCountDto() {
-    }
-
-    public ApplicantCountDto(final Long runnerPostId, final Long applicantCount) {
-        this.runnerPostId = runnerPostId;
-        this.applicantCount = (long) applicantCount;
-    }
-
-    public Long getRunnerPostId() {
-        return runnerPostId;
-    }
-
-    public Long getApplicantCount() {
-        return applicantCount;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        final ApplicantCountDto that = (ApplicantCountDto) o;
-        return applicantCount == that.applicantCount && Objects.equals(runnerPostId, that.runnerPostId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(runnerPostId, applicantCount);
-    }
+public record ApplicantCountDto(Long runnerPostId, Long applicantCount) {
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/dto/ApplicantCountMappingDto.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/dto/ApplicantCountMappingDto.java
@@ -1,0 +1,34 @@
+package touch.baton.domain.runnerpost.repository.dto;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class ApplicantCountMappingDto {
+
+    private final Map<Long, Long> applicantCounts;
+
+    public ApplicantCountMappingDto(final Map<Long, Long> applicantCounts) {
+        this.applicantCounts = applicantCounts;
+    }
+
+    public Long getApplicantCountByRunnerPostId(final Long runnerPostId) {
+        return applicantCounts.get(runnerPostId);
+    }
+
+    public Map<Long, Long> getApplicantCounts() {
+        return applicantCounts;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final ApplicantCountMappingDto that = (ApplicantCountMappingDto) o;
+        return Objects.equals(applicantCounts, that.applicantCounts);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(applicantCounts);
+    }
+}

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/dto/ApplicantCountMappingDto.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/repository/dto/ApplicantCountMappingDto.java
@@ -1,34 +1,10 @@
 package touch.baton.domain.runnerpost.repository.dto;
 
 import java.util.Map;
-import java.util.Objects;
 
-public class ApplicantCountMappingDto {
-
-    private final Map<Long, Long> applicantCounts;
-
-    public ApplicantCountMappingDto(final Map<Long, Long> applicantCounts) {
-        this.applicantCounts = applicantCounts;
-    }
+public record ApplicantCountMappingDto(Map<Long, Long> applicantCounts) {
 
     public Long getApplicantCountByRunnerPostId(final Long runnerPostId) {
         return applicantCounts.get(runnerPostId);
-    }
-
-    public Map<Long, Long> getApplicantCounts() {
-        return applicantCounts;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        final ApplicantCountMappingDto that = (ApplicantCountMappingDto) o;
-        return Objects.equals(applicantCounts, that.applicantCounts);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(applicantCounts);
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/service/RunnerPostReadService.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/service/RunnerPostReadService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.repository.RunnerPostReadRepository;
+import touch.baton.domain.runnerpost.repository.dto.ApplicantCountMappingDto;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
 import touch.baton.domain.tag.vo.TagReducedName;
 
@@ -28,7 +29,7 @@ public class RunnerPostReadService {
         return runnerPostReadRepository.findByTagReducedNameAndReviewStatus(pageable, tagReducedName, reviewStatus);
     }
 
-    public List<Long> readApplicantCountsByRunnerPostIds(final List<Long> runnerPostIds) {
-        return runnerPostReadRepository.countApplicantsByRunnerPostIds(runnerPostIds);
+    public ApplicantCountMappingDto readApplicantCountMappingByRunnerPostIds(final List<Long> runnerPostIds) {
+        return runnerPostReadRepository.findApplicantCountMappingByRunnerPostIds(runnerPostIds);
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/IsReviewed.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/IsReviewed.java
@@ -1,0 +1,33 @@
+package touch.baton.domain.runnerpost.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Embeddable
+public class IsReviewed {
+
+    @ColumnDefault(value = "false")
+    @Column(name = "is_reviewed", nullable = false)
+    private boolean value = false;
+
+    private IsReviewed(final boolean value) {
+        this.value = value;
+    }
+
+    public static IsReviewed notReviewed() {
+        return new IsReviewed(false);
+    }
+
+    public static IsReviewed reviewed() {
+        return new IsReviewed(true);
+    }
+}

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/IsReviewed.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/IsReviewed.java
@@ -30,6 +30,6 @@ public class IsReviewed {
     }
 
     public boolean getValue() {
-        return false;
+        return value;
     }
 }

--- a/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/IsReviewed.java
+++ b/backend/baton/src/main/java/touch/baton/domain/runnerpost/vo/IsReviewed.java
@@ -3,14 +3,12 @@ package touch.baton.domain.runnerpost.vo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 import static lombok.AccessLevel.PROTECTED;
 
 @EqualsAndHashCode
-@Getter
 @NoArgsConstructor(access = PROTECTED)
 @Embeddable
 public class IsReviewed {
@@ -29,5 +27,9 @@ public class IsReviewed {
 
     public static IsReviewed reviewed() {
         return new IsReviewed(true);
+    }
+
+    public boolean getValue() {
+        return false;
     }
 }

--- a/backend/baton/src/main/resources/db/migration/V20230920_1__add_new_runner_post_is_reviewed_column.sql
+++ b/backend/baton/src/main/resources/db/migration/V20230920_1__add_new_runner_post_is_reviewed_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE runner_post ADD COLUMN is_reviewed BOOLEAN DEFAULT FALSE;

--- a/backend/baton/src/main/resources/db/migration/V20230920_2__alter_runner_post_watched_count_column_name.sql
+++ b/backend/baton/src/main/resources/db/migration/V20230920_2__alter_runner_post_watched_count_column_name.sql
@@ -1,0 +1,1 @@
+ALTER TABLE runner_post CHANGE COLUMN watch_count watched_count INT DEFAULT 0 NOT NULL;

--- a/backend/baton/src/test/java/touch/baton/assure/repository/TestRunnerPostReadRepository.java
+++ b/backend/baton/src/test/java/touch/baton/assure/repository/TestRunnerPostReadRepository.java
@@ -13,6 +13,6 @@ public interface TestRunnerPostReadRepository extends RunnerPostReadRepository {
             throw new IllegalArgumentException("테스트에서 러너 게시글 식별자값으로 서포터 지원자 수 조회에 실패하였습니다.");
         }
 
-        return foundApplicants.get(0).getApplicantCount();
+        return foundApplicants.get(0).applicantCount();
     }
 }

--- a/backend/baton/src/test/java/touch/baton/assure/repository/TestRunnerPostReadRepository.java
+++ b/backend/baton/src/test/java/touch/baton/assure/repository/TestRunnerPostReadRepository.java
@@ -1,17 +1,18 @@
 package touch.baton.assure.repository;
 
 import touch.baton.domain.runnerpost.repository.RunnerPostReadRepository;
+import touch.baton.domain.runnerpost.repository.dto.ApplicantCountDto;
 
 import java.util.List;
 
 public interface TestRunnerPostReadRepository extends RunnerPostReadRepository {
 
     default Long countApplicantByRunnerPostId(final Long runnerPostId) {
-        final List<Long> foundApplicants = countApplicantsByRunnerPostIds(List.of(runnerPostId));
+        final List<ApplicantCountDto> foundApplicants = countApplicantsByRunnerPostIds(List.of(runnerPostId));
         if (foundApplicants.isEmpty()) {
             throw new IllegalArgumentException("테스트에서 러너 게시글 식별자값으로 서포터 지원자 수 조회에 실패하였습니다.");
         }
 
-        return foundApplicants.get(0);
+        return foundApplicants.get(0).getApplicantCount();
     }
 }

--- a/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostAssuredSupport.java
+++ b/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostAssuredSupport.java
@@ -147,7 +147,8 @@ public class RunnerPostAssuredSupport {
                 러너_게시글_태그_목록,
                 조회수,
                 지원한_서포터_수,
-                리뷰_상태.name()
+                리뷰_상태.name(),
+                러너_게시글.getIsReviewed().isValue()
         );
     }
 

--- a/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostAssuredSupport.java
+++ b/backend/baton/src/test/java/touch/baton/assure/runnerpost/RunnerPostAssuredSupport.java
@@ -148,7 +148,7 @@ public class RunnerPostAssuredSupport {
                 조회수,
                 지원한_서포터_수,
                 리뷰_상태.name(),
-                러너_게시글.getIsReviewed().isValue()
+                러너_게시글.getIsReviewed().getValue()
         );
     }
 

--- a/backend/baton/src/test/java/touch/baton/common/schedule/ScheduleRunnerPostRepositoryTest.java
+++ b/backend/baton/src/test/java/touch/baton/common/schedule/ScheduleRunnerPostRepositoryTest.java
@@ -10,6 +10,7 @@ import touch.baton.domain.member.Member;
 import touch.baton.domain.runner.Runner;
 import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.vo.Deadline;
+import touch.baton.domain.runnerpost.vo.IsReviewed;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
 import touch.baton.fixture.domain.MemberFixture;
 import touch.baton.fixture.domain.RunnerFixture;
@@ -19,7 +20,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static touch.baton.domain.runnerpost.vo.ReviewStatus.*;
+import static touch.baton.domain.runnerpost.vo.ReviewStatus.DONE;
+import static touch.baton.domain.runnerpost.vo.ReviewStatus.NOT_STARTED;
+import static touch.baton.domain.runnerpost.vo.ReviewStatus.OVERDUE;
 import static touch.baton.fixture.vo.DeadlineFixture.deadline;
 
 class ScheduleRunnerPostRepositoryTest extends RepositoryTestConfig {
@@ -68,8 +71,8 @@ class ScheduleRunnerPostRepositoryTest extends RepositoryTestConfig {
         final Deadline passedDeadlineOne = deadline(LocalDateTime.now().minusHours(10));
         final Deadline passedDeadlineTwo = deadline(LocalDateTime.now().minusHours(5));
         final ReviewStatus expectedReviewStatus = DONE;
-        final RunnerPost runnerPostOne = RunnerPostFixture.create(runner, passedDeadlineOne, expectedReviewStatus);
-        final RunnerPost runnerPostTwo = RunnerPostFixture.create(runner, passedDeadlineTwo, expectedReviewStatus);
+        final RunnerPost runnerPostOne = RunnerPostFixture.create(runner, passedDeadlineOne, expectedReviewStatus, IsReviewed.notReviewed());
+        final RunnerPost runnerPostTwo = RunnerPostFixture.create(runner, passedDeadlineTwo, expectedReviewStatus, IsReviewed.notReviewed());
         em.persist(runnerPostOne);
         em.persist(runnerPostTwo);
 
@@ -90,8 +93,8 @@ class ScheduleRunnerPostRepositoryTest extends RepositoryTestConfig {
         final Deadline passedDeadlineOne = deadline(LocalDateTime.now().plusHours(10));
         final Deadline passedDeadlineTwo = deadline(LocalDateTime.now().plusHours(5));
         final ReviewStatus expectedReviewStatus = NOT_STARTED;
-        final RunnerPost runnerPostOne = RunnerPostFixture.create(runner, passedDeadlineOne, expectedReviewStatus);
-        final RunnerPost runnerPostTwo = RunnerPostFixture.create(runner, passedDeadlineTwo, expectedReviewStatus);
+        final RunnerPost runnerPostOne = RunnerPostFixture.create(runner, passedDeadlineOne, expectedReviewStatus, IsReviewed.notReviewed());
+        final RunnerPost runnerPostTwo = RunnerPostFixture.create(runner, passedDeadlineTwo, expectedReviewStatus, IsReviewed.notReviewed());
         em.persist(runnerPostOne);
         em.persist(runnerPostTwo);
 

--- a/backend/baton/src/test/java/touch/baton/document/runnerpost/read/RunnerPostReadAllApiTest.java
+++ b/backend/baton/src/test/java/touch/baton/document/runnerpost/read/RunnerPostReadAllApiTest.java
@@ -14,10 +14,7 @@ import touch.baton.domain.runnerpost.controller.RunnerPostController;
 import touch.baton.domain.runnerpost.service.RunnerPostService;
 import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
-import touch.baton.domain.tag.RunnerPostTag;
 import touch.baton.domain.tag.Tag;
-import touch.baton.domain.tag.repository.TagRepository;
-import touch.baton.domain.tag.service.TagService;
 import touch.baton.fixture.domain.MemberFixture;
 import touch.baton.fixture.domain.RunnerFixture;
 import touch.baton.fixture.domain.RunnerPostFixture;
@@ -172,6 +169,7 @@ class RunnerPostReadAllApiTest extends RestdocsConfig {
                                 fieldWithPath("data.[].watchedCount").type(NUMBER).description("러너 게시글의 조회수"),
                                 fieldWithPath("data.[].applicantCount").type(NUMBER).description("러너 게시글에 신청한 서포터 수"),
                                 fieldWithPath("data.[].reviewStatus").type(STRING).description("러너 게시글 리뷰 상태"),
+                                fieldWithPath("data.[].isReviewed").type(BOOLEAN).description("러너 게시글을 리뷰해준 서포터에 대한 피드백 유무"),
                                 fieldWithPath("pageInfo.isFirst").type(BOOLEAN).description("첫 번째 페이지인지"),
                                 fieldWithPath("pageInfo.isLast").type(BOOLEAN).description("마지막 페이지 인지"),
                                 fieldWithPath("pageInfo.hasNext").type(BOOLEAN).description("다음 페이지가 있는지"),

--- a/backend/baton/src/test/java/touch/baton/document/runnerpost/read/RunnerPostReadSearchApiTest.java
+++ b/backend/baton/src/test/java/touch/baton/document/runnerpost/read/RunnerPostReadSearchApiTest.java
@@ -12,6 +12,7 @@ import touch.baton.config.RestdocsConfig;
 import touch.baton.domain.runner.Runner;
 import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.controller.RunnerPostReadController;
+import touch.baton.domain.runnerpost.repository.dto.ApplicantCountMappingDto;
 import touch.baton.domain.runnerpost.service.RunnerPostReadService;
 import touch.baton.domain.runnerpost.service.RunnerPostService;
 import touch.baton.domain.runnerpost.vo.Deadline;
@@ -24,6 +25,7 @@ import touch.baton.fixture.domain.TagFixture;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -51,6 +53,7 @@ class RunnerPostReadSearchApiTest extends RestdocsConfig {
 
     @MockBean
     private RunnerPostReadService runnerPostReadService;
+
     @MockBean
     private RunnerPostService runnerPostService;
 
@@ -81,8 +84,8 @@ class RunnerPostReadSearchApiTest extends RestdocsConfig {
         when(runnerPostReadService.readRunnerPostByTagNameAndReviewStatus(any(Pageable.class), anyString(), any(ReviewStatus.class)))
                 .thenReturn(pageRunnerPosts);
 
-        when(runnerPostReadService.readApplicantCountsByRunnerPostIds(anyList()))
-                .thenReturn(List.of(0L));
+        when(runnerPostReadService.readApplicantCountMappingByRunnerPostIds(anyList()))
+                .thenReturn(new ApplicantCountMappingDto(Map.of(1L, 0L)));
 
         // then
         mockMvc.perform(get("/api/v1/posts/runner/tags/search")

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/RunnerPostTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/RunnerPostTest.java
@@ -20,6 +20,7 @@ import touch.baton.domain.runnerpost.exception.RunnerPostDomainException;
 import touch.baton.domain.runnerpost.vo.CuriousContents;
 import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.ImplementedContents;
+import touch.baton.domain.runnerpost.vo.IsReviewed;
 import touch.baton.domain.runnerpost.vo.PostscriptContents;
 import touch.baton.domain.runnerpost.vo.PullRequestUrl;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
@@ -97,7 +98,7 @@ class RunnerPostTest {
 
         // when
         runnerPost.addAllRunnerPostTags(List.of(java, spring));
-         List<RunnerPostTag> runnerPostTags = runnerPost.getRunnerPostTags().getRunnerPostTags();
+        List<RunnerPostTag> runnerPostTags = runnerPost.getRunnerPostTags().getRunnerPostTags();
         final List<String> actualTagNames = runnerPostTags.stream()
                 .map(runnerPostTag -> runnerPostTag.getTag().getTagName().getValue())
                 .collect(Collectors.toList());
@@ -125,6 +126,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now()))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -144,6 +146,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now()))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(null)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -163,6 +166,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now()))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -183,6 +187,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now()))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -203,6 +208,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now()))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -223,6 +229,7 @@ class RunnerPostTest {
                     .deadline(null)
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -243,12 +250,34 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now()))
                     .watchedCount(null)
                     .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
                     .build()
             ).isInstanceOf(RunnerPostDomainException.class)
                     .hasMessage("RunnerPost 의 watchedCount 는 null 일 수 없습니다.");
+        }
+
+        @DisplayName("is reviewed 에 null 이 들어갈 경우 예외가 발생한다.")
+        @Test
+        void fail_if_isReviewed_is_null() {
+            assertThatThrownBy(() -> RunnerPost.builder()
+                    .title(new Title("아이"))
+                    .implementedContents(new ImplementedContents("김영한 짱짱맨"))
+                    .curiousContents(new CuriousContents("궁금한 점입니다."))
+                    .postscriptContents(new PostscriptContents("잘 부탁드립니다."))
+                    .pullRequestUrl(new PullRequestUrl("https://github.com/woowacourse-teams/2023-baton/pull/17"))
+                    .deadline(new Deadline(LocalDateTime.now()))
+                    .watchedCount(new WatchedCount(0))
+                    .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .isReviewed(null)
+                    .runner(runner)
+                    .supporter(supporter)
+                    .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
+                    .build()
+            ).isInstanceOf(RunnerPostDomainException.class)
+                    .hasMessage("RunnerPost 의 isReviewed 는 null 일 수 없습니다.");
         }
 
         @DisplayName("runner 에 null 이 들어갈 경우 예외가 발생한다.")
@@ -263,6 +292,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now()))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(null)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -283,6 +313,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now()))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(null)
@@ -334,6 +365,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(null)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -357,6 +389,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -380,6 +413,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now().minusDays(100)))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -413,6 +447,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.IN_PROGRESS)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -438,6 +473,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.NOT_STARTED)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -461,6 +497,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.DONE)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -484,6 +521,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.DONE)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -507,6 +545,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(ReviewStatus.DONE)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -531,6 +570,7 @@ class RunnerPostTest {
                     .deadline(new Deadline(LocalDateTime.now().plusHours(100)))
                     .watchedCount(new WatchedCount(0))
                     .reviewStatus(reviewStatus)
+                    .isReviewed(IsReviewed.notReviewed())
                     .runner(runner)
                     .supporter(supporter)
                     .runnerPostTags(new RunnerPostTags(new ArrayList<>()))

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostReadRepositoryTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostReadRepositoryTest.java
@@ -10,6 +10,8 @@ import touch.baton.config.RepositoryTestConfig;
 import touch.baton.domain.member.Member;
 import touch.baton.domain.runner.Runner;
 import touch.baton.domain.runnerpost.RunnerPost;
+import touch.baton.domain.runnerpost.repository.dto.ApplicantCountDto;
+import touch.baton.domain.runnerpost.repository.dto.ApplicantCountMappingDto;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
 import touch.baton.domain.supporter.Supporter;
 import touch.baton.domain.supporter.SupporterRunnerPost;
@@ -26,6 +28,7 @@ import touch.baton.fixture.domain.TagFixture;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static touch.baton.fixture.vo.DeadlineFixture.deadline;
@@ -68,17 +71,75 @@ class RunnerPostReadRepositoryTest extends RepositoryTestConfig {
         em.close();
 
         // when
-        final List<Long> actual = runnerPostReadRepository.countApplicantsByRunnerPostIds(List.of(
-                runnerPostOne.getId(),
+        final List<ApplicantCountDto> actual = runnerPostReadRepository.countApplicantsByRunnerPostIds(List.of(
                 runnerPostTwo.getId(),
                 runnerPostThree.getId(),
                 runnerPostFour.getId(),
                 runnerPostFive.getId(),
-                runnerPostSix.getId()
+                runnerPostSix.getId(),
+                runnerPostOne.getId()
         ));
 
         // then
-        final List<Long> expected = List.of(3L, 2L, 1L, 0L, 0L, 0L);
+        final List<ApplicantCountDto> expected = List.of(
+                new ApplicantCountDto(runnerPostTwo.getId(), 2L),
+                new ApplicantCountDto(runnerPostThree.getId(), 1L),
+                new ApplicantCountDto(runnerPostFour.getId(), 0L),
+                new ApplicantCountDto(runnerPostFive.getId(), 0L),
+                new ApplicantCountDto(runnerPostSix.getId(), 0L),
+                new ApplicantCountDto(runnerPostOne.getId(), 3L)
+        );
+
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    @DisplayName("러너 게시글 식별자값 목록으로 서포터 지원자 수 매핑 정보 조회에 성공한다.")
+    @Test
+    void findApplicantCountMappingByRunnerPostIds() {
+        // given
+        final Runner hyenaRunner = persistRunner(MemberFixture.createHyena());
+        final Supporter ditooSupporter = persistSupporter(MemberFixture.createDitoo());
+        final Supporter ethanSupporter = persistSupporter(MemberFixture.createEthan());
+        final Supporter judySupporter = persistSupporter(MemberFixture.createJudy());
+
+        final RunnerPost runnerPostOne = persistRunnerPost(hyenaRunner);
+        final RunnerPost runnerPostTwo = persistRunnerPost(hyenaRunner);
+        final RunnerPost runnerPostThree = persistRunnerPost(hyenaRunner);
+        final RunnerPost runnerPostFour = persistRunnerPost(hyenaRunner);
+        final RunnerPost runnerPostFive = persistRunnerPost(hyenaRunner);
+        final RunnerPost runnerPostSix = persistRunnerPost(hyenaRunner);
+
+        persistApplicant(ditooSupporter, runnerPostOne);
+        persistApplicant(ethanSupporter, runnerPostOne);
+        persistApplicant(judySupporter, runnerPostOne);
+
+        persistApplicant(ditooSupporter, runnerPostTwo);
+        persistApplicant(ethanSupporter, runnerPostTwo);
+
+        persistApplicant(ditooSupporter, runnerPostThree);
+
+        em.flush();
+        em.close();
+
+        // when
+        final ApplicantCountMappingDto actual = runnerPostReadRepository.findApplicantCountMappingByRunnerPostIds(List.of(
+                runnerPostTwo.getId(),
+                runnerPostThree.getId(),
+                runnerPostFour.getId(),
+                runnerPostFive.getId(),
+                runnerPostSix.getId(),
+                runnerPostOne.getId()
+        ));
+
+        // then
+        final ApplicantCountMappingDto expected = new ApplicantCountMappingDto(Map.of(
+                runnerPostTwo.getId(), 2L,
+                runnerPostThree.getId(), 1L,
+                runnerPostFour.getId(), 0L,
+                runnerPostFive.getId(), 0L,
+                runnerPostSix.getId(), 0L,
+                runnerPostOne.getId(), 3L
+        ));
 
         assertThat(actual).isEqualTo(expected);
     }

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostRepositoryDeleteTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostRepositoryDeleteTest.java
@@ -20,6 +20,7 @@ import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.vo.CuriousContents;
 import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.ImplementedContents;
+import touch.baton.domain.runnerpost.vo.IsReviewed;
 import touch.baton.domain.runnerpost.vo.PostscriptContents;
 import touch.baton.domain.runnerpost.vo.PullRequestUrl;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
@@ -73,6 +74,7 @@ class RunnerPostRepositoryDeleteTest extends RepositoryTestConfig {
                 .watchedCount(new WatchedCount(1))
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
                 .reviewStatus(ReviewStatus.NOT_STARTED)
+                .isReviewed(IsReviewed.notReviewed())
                 .runner(saveRunner)
                 .supporter(null)
                 .build();

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostRepositoryReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/RunnerPostRepositoryReadTest.java
@@ -20,6 +20,7 @@ import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.vo.CuriousContents;
 import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.ImplementedContents;
+import touch.baton.domain.runnerpost.vo.IsReviewed;
 import touch.baton.domain.runnerpost.vo.PostscriptContents;
 import touch.baton.domain.runnerpost.vo.PullRequestUrl;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
@@ -74,6 +75,7 @@ class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
                 .watchedCount(new WatchedCount(1))
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
                 .reviewStatus(ReviewStatus.NOT_STARTED)
+                .isReviewed(IsReviewed.notReviewed())
                 .runner(saveRunner)
                 .supporter(null)
                 .build();

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/read/RunnerPostRepositoryReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/read/RunnerPostRepositoryReadTest.java
@@ -101,8 +101,8 @@ class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
         final Runner runner = RunnerFixture.createRunner(ditoo);
         em.persist(runner);
 
-        em.close();
         em.flush();
+        em.close();
 
         final RunnerPost runnerPost = RunnerPostFixture.create(title("제 코드를 리뷰해주세요"),
                 implementedContents("제 코드의 내용은 이렇습니다."),

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/read/RunnerPostRepositoryReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/read/RunnerPostRepositoryReadTest.java
@@ -9,16 +9,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import touch.baton.config.RepositoryTestConfig;
 import touch.baton.domain.member.Member;
-import touch.baton.domain.member.repository.MemberRepository;
 import touch.baton.domain.runner.Runner;
-import touch.baton.domain.runner.repository.RunnerRepository;
 import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.repository.RunnerPostRepository;
 import touch.baton.domain.runnerpost.vo.IsReviewed;
 import touch.baton.domain.tag.RunnerPostTag;
 import touch.baton.domain.tag.Tag;
 import touch.baton.domain.tag.repository.RunnerPostTagRepository;
-import touch.baton.domain.tag.repository.TagRepository;
 import touch.baton.fixture.domain.MemberFixture;
 import touch.baton.fixture.domain.RunnerFixture;
 import touch.baton.fixture.domain.RunnerPostFixture;
@@ -45,16 +42,7 @@ import static touch.baton.util.TestDateFormatUtil.createExpireDate;
 class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
 
     @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private RunnerRepository runnerRepository;
-
-    @Autowired
     private RunnerPostRepository runnerPostRepository;
-
-    @Autowired
-    private TagRepository tagRepository;
 
     @Autowired
     private RunnerPostTagRepository runnerPostTagRepository;
@@ -94,6 +82,9 @@ class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
 
         runnerPost.addAllRunnerPostTags(List.of(javaRunnerPostTag, springRunnerPostTag));
 
+        em.flush();
+        em.close();
+
         // when
         final List<RunnerPostTag> expected = runnerPostTagRepository.joinTagByRunnerPostId(runnerPost.getId());
 
@@ -109,6 +100,9 @@ class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
         em.persist(ditoo);
         final Runner runner = RunnerFixture.createRunner(ditoo);
         em.persist(runner);
+
+        em.close();
+        em.flush();
 
         final RunnerPost runnerPost = RunnerPostFixture.create(title("제 코드를 리뷰해주세요"),
                 implementedContents("제 코드의 내용은 이렇습니다."),

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/read/RunnerPostRepositoryReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/repository/read/RunnerPostRepositoryReadTest.java
@@ -14,6 +14,7 @@ import touch.baton.domain.runner.Runner;
 import touch.baton.domain.runner.repository.RunnerRepository;
 import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.repository.RunnerPostRepository;
+import touch.baton.domain.runnerpost.vo.IsReviewed;
 import touch.baton.domain.tag.RunnerPostTag;
 import touch.baton.domain.tag.Tag;
 import touch.baton.domain.tag.repository.RunnerPostTagRepository;
@@ -78,6 +79,7 @@ class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
                 deadline(LocalDateTime.now().plusHours(10)),
                 watchedCount(0),
                 NOT_STARTED,
+                IsReviewed.notReviewed(),
                 runner,
                 null,
                 runnerPostTags(new ArrayList<>()));
@@ -116,6 +118,7 @@ class RunnerPostRepositoryReadTest extends RepositoryTestConfig {
                 deadline(LocalDateTime.now().plusHours(10)),
                 watchedCount(0),
                 NOT_STARTED,
+                IsReviewed.notReviewed(),
                 runner,
                 null,
                 runnerPostTags(new ArrayList<>()));

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostReadServiceTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostReadServiceTest.java
@@ -10,6 +10,7 @@ import touch.baton.config.ServiceTestConfig;
 import touch.baton.domain.member.Member;
 import touch.baton.domain.runner.Runner;
 import touch.baton.domain.runnerpost.RunnerPost;
+import touch.baton.domain.runnerpost.repository.dto.ApplicantCountMappingDto;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
 import touch.baton.domain.supporter.Supporter;
 import touch.baton.domain.tag.Tag;
@@ -22,6 +23,7 @@ import touch.baton.fixture.domain.TagFixture;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -138,10 +140,14 @@ class RunnerPostReadServiceTest extends ServiceTestConfig {
                 savedRunnerPostThree.getId()
         );
 
-        final List<Long> actual = runnerPostReadService.readApplicantCountsByRunnerPostIds(runnerPostIds);
+        final ApplicantCountMappingDto actual = runnerPostReadService.readApplicantCountMappingByRunnerPostIds(runnerPostIds);
 
         // then
-        final List<Long> expected = List.of(3L, 0L, 2L);
+        final ApplicantCountMappingDto expected = new ApplicantCountMappingDto(Map.of(
+                savedRunnerPostOne.getId(), 3L,
+                savedRunnerPostTwo.getId(), 0L,
+                savedRunnerPostThree.getId(), 2L
+        ));
 
         assertThat(actual).isEqualTo(expected);
     }

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceReadTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceReadTest.java
@@ -22,6 +22,7 @@ import touch.baton.domain.runnerpost.exception.RunnerPostBusinessException;
 import touch.baton.domain.runnerpost.vo.CuriousContents;
 import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.ImplementedContents;
+import touch.baton.domain.runnerpost.vo.IsReviewed;
 import touch.baton.domain.runnerpost.vo.PostscriptContents;
 import touch.baton.domain.runnerpost.vo.PullRequestUrl;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
@@ -96,6 +97,7 @@ class RunnerPostServiceReadTest extends ServiceTestConfig {
                 .watchedCount(new WatchedCount(0))
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
                 .reviewStatus(NOT_STARTED)
+                .isReviewed(IsReviewed.notReviewed())
                 .runner(runner)
                 .supporter(null)
                 .build();

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceUpdateTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostServiceUpdateTest.java
@@ -10,6 +10,7 @@ import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.exception.RunnerPostBusinessException;
 import touch.baton.domain.runnerpost.exception.RunnerPostDomainException;
 import touch.baton.domain.runnerpost.service.dto.RunnerPostUpdateRequest;
+import touch.baton.domain.runnerpost.vo.IsReviewed;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
 import touch.baton.domain.supporter.Supporter;
 import touch.baton.fixture.domain.MemberFixture;
@@ -140,7 +141,8 @@ class RunnerPostServiceUpdateTest extends ServiceTestConfig {
     @Test
     void updateRunnerPostReviewStatusDone() {
         // given
-        final RunnerPost targetRunnerPost = runnerPostRepository.save(RunnerPostFixture.createWithReviewStatus(runner, assignedSupporter, IN_PROGRESS));
+        final IsReviewed isReviewed = IsReviewed.notReviewed();
+        final RunnerPost targetRunnerPost = runnerPostRepository.save(RunnerPostFixture.createWithReviewStatus(runner, assignedSupporter, IN_PROGRESS, isReviewed));
 
         // when
         runnerPostService.updateRunnerPostReviewStatusDone(targetRunnerPost.getId(), assignedSupporter);
@@ -156,7 +158,8 @@ class RunnerPostServiceUpdateTest extends ServiceTestConfig {
     @Test
     void fail_updateRunnerPostReviewStatusDone_if_invalid_runnerPostId() {
         // given
-        runnerPostRepository.save(RunnerPostFixture.createWithReviewStatus(runner, assignedSupporter, IN_PROGRESS));
+        final IsReviewed isReviewed = IsReviewed.notReviewed();
+        runnerPostRepository.save(RunnerPostFixture.createWithReviewStatus(runner, assignedSupporter, IN_PROGRESS, isReviewed));
         final Long unsavedRunnerPostId = 100000L;
 
         // when, then
@@ -168,7 +171,8 @@ class RunnerPostServiceUpdateTest extends ServiceTestConfig {
     @Test
     void fail_updateRunnerPostReviewStatusDone_if_supporter_is_null() {
         // given
-        final RunnerPost targetRunnerPost = runnerPostRepository.save(RunnerPostFixture.createWithReviewStatus(runner, null, IN_PROGRESS));
+        final IsReviewed isReviewed = IsReviewed.notReviewed();
+        final RunnerPost targetRunnerPost = runnerPostRepository.save(RunnerPostFixture.createWithReviewStatus(runner, null, IN_PROGRESS, isReviewed));
 
         // when, then
         assertThatThrownBy(() -> runnerPostService.updateRunnerPostReviewStatusDone(targetRunnerPost.getId(), assignedSupporter))
@@ -179,7 +183,8 @@ class RunnerPostServiceUpdateTest extends ServiceTestConfig {
     @Test
     void fail_updateRunnerPostReviewStatusDone_if_different_supporter_is_assigned() {
         // given
-        final RunnerPost targetRunnerPost = runnerPostRepository.save(RunnerPostFixture.createWithReviewStatus(runner, assignedSupporter, IN_PROGRESS));
+        final IsReviewed isReviewed = IsReviewed.notReviewed();
+        final RunnerPost targetRunnerPost = runnerPostRepository.save(RunnerPostFixture.createWithReviewStatus(runner, assignedSupporter, IN_PROGRESS, isReviewed));
         final Member differentMember = memberRepository.save(MemberFixture.createHyena());
         final Supporter differentSupporter = supporterRepository.save(SupporterFixture.create(differentMember));
 
@@ -192,7 +197,8 @@ class RunnerPostServiceUpdateTest extends ServiceTestConfig {
     @Test
     void fail_updateRunnerPostReviewStatusDone_if_reviewStatus_is_overdue() {
         // given
-        final RunnerPost targetRunnerPost = runnerPostRepository.save(RunnerPostFixture.createWithReviewStatus(runner, assignedSupporter, OVERDUE));
+        final IsReviewed isReviewed = IsReviewed.notReviewed();
+        final RunnerPost targetRunnerPost = runnerPostRepository.save(RunnerPostFixture.createWithReviewStatus(runner, assignedSupporter, OVERDUE, isReviewed));
 
         // when, then
         assertThatThrownBy(() -> runnerPostService.updateRunnerPostReviewStatusDone(targetRunnerPost.getId(), assignedSupporter))

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostUpdateApplicantCancelationServiceTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/service/RunnerPostUpdateApplicantCancelationServiceTest.java
@@ -9,6 +9,7 @@ import touch.baton.domain.runner.Runner;
 import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.exception.RunnerPostBusinessException;
 import touch.baton.domain.runnerpost.vo.Deadline;
+import touch.baton.domain.runnerpost.vo.IsReviewed;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
 import touch.baton.domain.supporter.Supporter;
 import touch.baton.domain.supporter.SupporterRunnerPost;
@@ -84,12 +85,14 @@ public class RunnerPostUpdateApplicantCancelationServiceTest extends ServiceTest
     @Test
     void fail_when_runnerPost_reviewStatus_is_not_NOT_STARTED() {
         // given
+        final IsReviewed isReviewed = IsReviewed.notReviewed();
         final RunnerPost runnerPost = runnerPostRepository.save(
                 RunnerPostFixture.create(
                         revieweeRunner,
                         applicantSupporter,
                         new Deadline(LocalDateTime.now().plusHours(100)),
-                        ReviewStatus.IN_PROGRESS
+                        ReviewStatus.IN_PROGRESS,
+                        isReviewed
                 ));
         final SupporterRunnerPost supporterRunnerPost = SupporterRunnerPostFixture.create(runnerPost, applicantSupporter);
         supporterRunnerPostRepository.save(supporterRunnerPost);

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/vo/IsReviewedTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/vo/IsReviewedTest.java
@@ -1,0 +1,21 @@
+package touch.baton.domain.runnerpost.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IsReviewedTest {
+
+    @DisplayName("기본 생성의 default 값은 false 이다.")
+    @Test
+    void default_is_false() {
+        // given
+        final IsReviewed isReviewed = new IsReviewed();
+
+        // expect
+        final boolean actual = isReviewed.isValue();
+
+        assertThat(actual).isFalse();
+    }
+}

--- a/backend/baton/src/test/java/touch/baton/domain/runnerpost/vo/IsReviewedTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/runnerpost/vo/IsReviewedTest.java
@@ -14,7 +14,7 @@ class IsReviewedTest {
         final IsReviewed isReviewed = new IsReviewed();
 
         // expect
-        final boolean actual = isReviewed.isValue();
+        final boolean actual = isReviewed.getValue();
 
         assertThat(actual).isFalse();
     }

--- a/backend/baton/src/test/java/touch/baton/domain/supporter/SupporterFeedbackTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/supporter/SupporterFeedbackTest.java
@@ -9,6 +9,7 @@ import touch.baton.domain.feedback.vo.Description;
 import touch.baton.domain.feedback.vo.ReviewType;
 import touch.baton.domain.runner.Runner;
 import touch.baton.domain.runnerpost.RunnerPost;
+import touch.baton.domain.runnerpost.vo.IsReviewed;
 import touch.baton.domain.supporter.vo.ReviewCount;
 import touch.baton.fixture.domain.MemberFixture;
 import touch.baton.fixture.domain.RunnerFixture;
@@ -57,6 +58,7 @@ class SupporterFeedbackTest {
                     deadline(LocalDateTime.now().plusHours(10)),
                     watchedCount(0),
                     NOT_STARTED,
+                    IsReviewed.notReviewed(),
                     runner,
                     supporter,
                     RunnerPostTagsFixture.runnerPostTags(new ArrayList<>()));

--- a/backend/baton/src/test/java/touch/baton/domain/tag/RunnerPostTagTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/tag/RunnerPostTagTest.java
@@ -17,6 +17,7 @@ import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.vo.CuriousContents;
 import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.ImplementedContents;
+import touch.baton.domain.runnerpost.vo.IsReviewed;
 import touch.baton.domain.runnerpost.vo.PostscriptContents;
 import touch.baton.domain.runnerpost.vo.PullRequestUrl;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
@@ -76,6 +77,7 @@ class RunnerPostTagTest {
                 .deadline(new Deadline(LocalDateTime.now()))
                 .watchedCount(new WatchedCount(0))
                 .reviewStatus(ReviewStatus.NOT_STARTED)
+                .isReviewed(IsReviewed.notReviewed())
                 .runner(runner)
                 .supporter(supporter)
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))

--- a/backend/baton/src/test/java/touch/baton/domain/tag/repository/RunnerPostTagRepositoryTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/tag/repository/RunnerPostTagRepositoryTest.java
@@ -22,6 +22,7 @@ import touch.baton.domain.runnerpost.repository.RunnerPostRepository;
 import touch.baton.domain.runnerpost.vo.CuriousContents;
 import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.ImplementedContents;
+import touch.baton.domain.runnerpost.vo.IsReviewed;
 import touch.baton.domain.runnerpost.vo.PostscriptContents;
 import touch.baton.domain.runnerpost.vo.PullRequestUrl;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
@@ -85,6 +86,7 @@ class RunnerPostTagRepositoryTest extends RepositoryTestConfig {
                 .watchedCount(new WatchedCount(1))
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
                 .reviewStatus(ReviewStatus.NOT_STARTED)
+                .isReviewed(IsReviewed.notReviewed())
                 .runner(saveRunner)
                 .supporter(null)
                 .build();
@@ -142,6 +144,7 @@ class RunnerPostTagRepositoryTest extends RepositoryTestConfig {
                 .watchedCount(new WatchedCount(1))
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
                 .reviewStatus(ReviewStatus.NOT_STARTED)
+                .isReviewed(IsReviewed.notReviewed())
                 .runner(saveRunner)
                 .supporter(null)
                 .build();

--- a/backend/baton/src/test/java/touch/baton/domain/technicaltag/repository/SupporterTechnicalTagRepositoryTest.java
+++ b/backend/baton/src/test/java/touch/baton/domain/technicaltag/repository/SupporterTechnicalTagRepositoryTest.java
@@ -24,28 +24,29 @@ class SupporterTechnicalTagRepositoryTest extends RepositoryTestConfig {
     private SupporterTechnicalTagRepository supporterTechnicalTagRepository;
 
     @Autowired
-    private EntityManager entityManager;
+    private EntityManager em;
 
     @DisplayName("batch 로 supporter 의 모든 SupporterTechnicalTag 를 삭제한다.")
     @Test
     void deleteBySupporter() {
         // given
         final Member member = MemberFixture.createDitoo();
-        entityManager.persist(member);
+        em.persist(member);
         final Supporter supporter = SupporterFixture.create(member);
-        entityManager.persist(supporter);
+        em.persist(supporter);
         final TechnicalTag technicalTag1 = TechnicalTagFixture.createReact();
         final TechnicalTag technicalTag2 = TechnicalTagFixture.createSpring();
         final TechnicalTag technicalTag3 = TechnicalTagFixture.createJava();
-        entityManager.persist(technicalTag1);
-        entityManager.persist(technicalTag2);
-        entityManager.persist(technicalTag3);
+        em.persist(technicalTag1);
+        em.persist(technicalTag2);
+        em.persist(technicalTag3);
         final SupporterTechnicalTag supporterTechnicalTag1 = SupporterTechnicalTagFixture.create(supporter, technicalTag1);
         final SupporterTechnicalTag supporterTechnicalTag2 = SupporterTechnicalTagFixture.create(supporter, technicalTag2);
         final SupporterTechnicalTag supporterTechnicalTag3 = SupporterTechnicalTagFixture.create(supporter, technicalTag3);
         final List<SupporterTechnicalTag> savedSupporterTechnicalTags = List.of(supporterTechnicalTag1, supporterTechnicalTag2, supporterTechnicalTag3);
         supporterTechnicalTagRepository.saveAll(savedSupporterTechnicalTags);
-        entityManager.flush();
+        em.flush();
+        em.close();
 
         // when
         final int expected = savedSupporterTechnicalTags.size();

--- a/backend/baton/src/test/java/touch/baton/fixture/domain/RunnerPostFixture.java
+++ b/backend/baton/src/test/java/touch/baton/fixture/domain/RunnerPostFixture.java
@@ -7,6 +7,7 @@ import touch.baton.domain.runnerpost.RunnerPost;
 import touch.baton.domain.runnerpost.vo.CuriousContents;
 import touch.baton.domain.runnerpost.vo.Deadline;
 import touch.baton.domain.runnerpost.vo.ImplementedContents;
+import touch.baton.domain.runnerpost.vo.IsReviewed;
 import touch.baton.domain.runnerpost.vo.PostscriptContents;
 import touch.baton.domain.runnerpost.vo.PullRequestUrl;
 import touch.baton.domain.runnerpost.vo.ReviewStatus;
@@ -33,6 +34,7 @@ public abstract class RunnerPostFixture {
                                     final Deadline deadline,
                                     final WatchedCount watchedCount,
                                     final ReviewStatus reviewStatus,
+                                    final IsReviewed isReviewed,
                                     final Runner runner,
                                     final Supporter supporter,
                                     final RunnerPostTags runnerPostTags
@@ -46,6 +48,7 @@ public abstract class RunnerPostFixture {
                 .deadline(deadline)
                 .watchedCount(watchedCount)
                 .reviewStatus(reviewStatus)
+                .isReviewed(isReviewed)
                 .runner(runner)
                 .supporter(supporter)
                 .runnerPostTags(runnerPostTags)
@@ -62,13 +65,18 @@ public abstract class RunnerPostFixture {
                 .deadline(deadline)
                 .watchedCount(new WatchedCount(0))
                 .reviewStatus(ReviewStatus.NOT_STARTED)
+                .isReviewed(IsReviewed.notReviewed())
                 .runner(runner)
                 .supporter(null)
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
                 .build();
     }
 
-    public static RunnerPost create(final Runner runner, final Deadline deadline, final ReviewStatus reviewStatus) {
+    public static RunnerPost create(final Runner runner,
+                                    final Deadline deadline,
+                                    final ReviewStatus reviewStatus,
+                                    final IsReviewed isReviewed
+    ) {
         return RunnerPost.builder()
                 .title(new Title("테스트 제목"))
                 .implementedContents(new ImplementedContents("테스트 내용"))
@@ -78,6 +86,7 @@ public abstract class RunnerPostFixture {
                 .deadline(deadline)
                 .watchedCount(new WatchedCount(0))
                 .reviewStatus(reviewStatus)
+                .isReviewed(isReviewed)
                 .runner(runner)
                 .supporter(null)
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -94,6 +103,7 @@ public abstract class RunnerPostFixture {
                 .deadline(deadline)
                 .watchedCount(new WatchedCount(0))
                 .reviewStatus(ReviewStatus.NOT_STARTED)
+                .isReviewed(IsReviewed.notReviewed())
                 .runner(runner)
                 .supporter(null)
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
@@ -108,22 +118,6 @@ public abstract class RunnerPostFixture {
         return runnerPost;
     }
 
-
-    public static RunnerPost create(final Runner runner, final RunnerPostTags runnerPostTags, final Deadline deadline) {
-        return RunnerPost.builder()
-                .title(new Title("테스트 제목"))
-                .implementedContents(new ImplementedContents("테스트 내용"))
-                .curiousContents(new CuriousContents("테스트 궁금 점"))
-                .postscriptContents(new PostscriptContents("테스트 참고 사항"))
-                .pullRequestUrl(new PullRequestUrl("https://테스트"))
-                .deadline(deadline)
-                .watchedCount(new WatchedCount(0))
-                .runner(runner)
-                .supporter(null)
-                .runnerPostTags(runnerPostTags)
-                .build();
-    }
-
     public static RunnerPost create(final Runner runner, final Supporter supporter) {
         return RunnerPost.builder()
                 .title(new Title("테스트 제목"))
@@ -136,11 +130,16 @@ public abstract class RunnerPostFixture {
                 .runner(runner)
                 .supporter(supporter)
                 .reviewStatus(ReviewStatus.NOT_STARTED)
+                .isReviewed(IsReviewed.notReviewed())
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
                 .build();
     }
 
-    public static RunnerPost createWithReviewStatus(final Runner runner, final Supporter supporter, final ReviewStatus reviewStatus) {
+    public static RunnerPost createWithReviewStatus(final Runner runner,
+                                                    final Supporter supporter,
+                                                    final ReviewStatus reviewStatus,
+                                                    final IsReviewed isReviewed
+    ) {
         return RunnerPost.builder()
                 .title(new Title("테스트 제목"))
                 .implementedContents(new ImplementedContents("테스트 내용"))
@@ -152,6 +151,7 @@ public abstract class RunnerPostFixture {
                 .runner(runner)
                 .supporter(supporter)
                 .reviewStatus(reviewStatus)
+                .isReviewed(isReviewed)
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
                 .build();
     }
@@ -168,6 +168,7 @@ public abstract class RunnerPostFixture {
                 .runner(runner)
                 .supporter(supporter)
                 .reviewStatus(ReviewStatus.NOT_STARTED)
+                .isReviewed(IsReviewed.notReviewed())
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
                 .build();
     }
@@ -175,7 +176,8 @@ public abstract class RunnerPostFixture {
     public static RunnerPost create(final Runner runner,
                                     final Supporter supporter,
                                     final Deadline deadline,
-                                    final ReviewStatus reviewStatus
+                                    final ReviewStatus reviewStatus,
+                                    final IsReviewed isReviewed
     ) {
         return RunnerPost.builder()
                 .title(new Title("테스트 제목"))
@@ -188,22 +190,8 @@ public abstract class RunnerPostFixture {
                 .runner(runner)
                 .supporter(supporter)
                 .reviewStatus(reviewStatus)
+                .isReviewed(isReviewed)
                 .runnerPostTags(new RunnerPostTags(new ArrayList<>()))
-                .build();
-    }
-
-    public static RunnerPost create(final Runner runner, final Supporter supporter, final RunnerPostTags runnerPostTags, final Deadline deadline) {
-        return RunnerPost.builder()
-                .title(new Title("테스트 제목"))
-                .implementedContents(new ImplementedContents("테스트 내용"))
-                .curiousContents(new CuriousContents("테스트 궁금 점"))
-                .postscriptContents(new PostscriptContents("테스트 참고 사항"))
-                .pullRequestUrl(new PullRequestUrl("https://테스트"))
-                .deadline(deadline)
-                .watchedCount(new WatchedCount(0))
-                .runner(runner)
-                .supporter(supporter)
-                .runnerPostTags(runnerPostTags)
                 .build();
     }
 }


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #548 

## 참고사항
- RunnerPost에 피드백 작성 유무 필드 IsReviewed 추가
- IsReviewed 내부 정적 팩터리 메서드로 notReviewed(), reviewed() 메서드 구현
- RunnerPost SimpleInMyPage 내부 필드에 IsReviewed 추가
- 영향가는 테스트 수정
- flyway 수정 (러너 게시글에 피드백 작성 유무 컬럼인 isReviewed 추가, 러너 게시글 조회수 watch_count 컬럼명을 watched_count로 수정)
- 서포터 지원자 수를 조회할 때 DTO(ApplicantCountMappingDto)를 반환하도록 수정