### PR TITLE
글 작성 후 결과 페이지 추가 및 마감기한 기본값 수정

### DIFF
--- a/frontend/cypress/e2e/app.cy.ts
+++ b/frontend/cypress/e2e/app.cy.ts
@@ -95,7 +95,7 @@ describe('러너 E2E 테스트', () => {
         .then((cur) => {
           cy.wrap(ele)
             .find('button')
-            .should(Number(cur.text()) > 0 ? 'be.visible' : 'not.be.visible');
+            .should(Number(cur.text()) > 0 ? 'be.enabled' : 'be.disabled');
         });
     });
   });

--- a/frontend/src/components/MyPage/MyPagePostItem/MyPagePostItem.tsx
+++ b/frontend/src/components/MyPage/MyPagePostItem/MyPagePostItem.tsx
@@ -99,7 +99,7 @@ const S = {
       gap: 12px;
     }
 
-    & button:hover {
+    & button:hover:enabled {
       transition: all 0.3s ease;
       background-color: var(--baton-red);
       color: var(--white-color);

--- a/frontend/src/components/common/Button/Button.tsx
+++ b/frontend/src/components/common/Button/Button.tsx
@@ -30,7 +30,7 @@ const Button = ({
         data-type={dataType}
         $colorTheme={colorTheme}
         type={type}
-        $disabled={disabled}
+        disabled={disabled}
         $fontSize={fontSize}
         $fontWeight={fontWeight}
         onClick={onClick}
@@ -71,7 +71,9 @@ const S = {
     font-size: ${({ $fontSize }) => $fontSize || '18px'};
     font-weight: ${({ $fontWeight }) => $fontWeight || '400'};
 
-    display: ${({ $disabled }) => ($disabled ? 'none' : 'block')};
+    &:disabled {
+      ${() => themeStyles['GRAY']}
+    }
 
     @media (max-width: 768px) {
       width: ${({ $width }) => $width || '180px'};

--- a/frontend/src/hooks/usePageRouter.ts
+++ b/frontend/src/hooks/usePageRouter.ts
@@ -53,6 +53,10 @@ export const usePageRouter = () => {
     navigate(ROUTER_PATH.NOTICE);
   };
 
+  const goToResultPage = () => {
+    navigate(ROUTER_PATH.RESULT);
+  };
+
   const goBack = () => {
     navigate(-1);
   };

--- a/frontend/src/hooks/usePageRouter.ts
+++ b/frontend/src/hooks/usePageRouter.ts
@@ -73,6 +73,7 @@ export const usePageRouter = () => {
     goToSupporterFeedbackPage,
     goToProfileEditPage,
     goToNoticePage,
+    goToResultPage,
     goBack,
   };
 };

--- a/frontend/src/mocks/data/myPagePost/myPagePostList.json
+++ b/frontend/src/mocks/data/myPagePost/myPagePostList.json
@@ -13,7 +13,7 @@
     {
       "runnerPostId": 22,
       "title": "시작안한 리뷰2",
-      "deadline": "마감기한2",
+      "deadline": "2099-10-13T11:30",
       "tags": ["java", "자바"],
       "reviewStatus": "NOT_STARTED",
       "applicantCount": 4,
@@ -22,7 +22,7 @@
     {
       "runnerPostId": 34,
       "title": "시작안한 리뷰3",
-      "deadline": "마감기한3",
+      "deadline": "2099-10-13T11:30",
       "tags": ["java", "자바"],
       "reviewStatus": "NOT_STARTED",
       "applicantCount": 4,
@@ -31,7 +31,7 @@
     {
       "runnerPostId": 45,
       "title": "시작안한 리뷰3",
-      "deadline": "마감기한3",
+      "deadline": "2099-10-13T11:30",
       "tags": ["java", "자바"],
       "reviewStatus": "NOT_STARTED",
       "applicantCount": 4,
@@ -40,7 +40,7 @@
     {
       "runnerPostId": 56,
       "title": "시작안한 리뷰3",
-      "deadline": "마감기한3",
+      "deadline": "2099-10-13T11:30",
       "tags": ["java", "자바"],
       "reviewStatus": "NOT_STARTED",
       "applicantCount": 4,
@@ -49,7 +49,7 @@
     {
       "runnerPostId": 67,
       "title": "시작안한 리뷰3",
-      "deadline": "마감기한3",
+      "deadline": "2099-10-13T11:30",
       "tags": ["java", "자바"],
       "reviewStatus": "NOT_STARTED",
       "applicantCount": 4,

--- a/frontend/src/mocks/data/supporterProfilePost.json
+++ b/frontend/src/mocks/data/supporterProfilePost.json
@@ -3,7 +3,7 @@
     {
       "runnerPostId": 1,
       "title": "이 서포터가 완료한 리뷰 1",
-      "deadline": "마감기한",
+      "deadline": "2022-10-13T11:30",
       "tags": ["java", "JAVA"],
       "watchedCount": 341,
       "applicantCount": 4,
@@ -12,7 +12,7 @@
     {
       "runnerPostId": 2,
       "title": "이 서포터가 완료한 리뷰 2",
-      "deadline": "마감기한",
+      "deadline": "2022-10-13T11:30",
       "tags": ["java", "JAVA"],
       "watchedCount": 34,
       "applicantCount": 41,
@@ -21,7 +21,7 @@
     {
       "runnerPostId": 3,
       "title": "이 서포터가 완료한 리뷰 3",
-      "deadline": "마감기한",
+      "deadline": "2022-10-13T11:30",
       "tags": ["java", "JAVA"],
       "watchedCount": 2224,
       "applicantCount": 4,

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -1,0 +1,50 @@
+import Button from '@/components/common/Button/Button';
+import { usePageRouter } from '@/hooks/usePageRouter';
+import Layout from '@/layout/Layout';
+import React from 'react';
+import styled from 'styled-components';
+
+const ResultPage = () => {
+  const { goToMyPage } = usePageRouter();
+
+  return (
+    <Layout>
+      <S.ResultPageContainer>
+        <S.Message>
+          {'리뷰 요청글 생성이 완료되었습니다.\n'}
+          <S.Bold>러너 마이페이지</S.Bold>에서 <S.Bold>서포터를 선택</S.Bold>하고 리뷰를 진행해 주세요.
+        </S.Message>
+        <Button colorTheme="WHITE" onClick={goToMyPage}>
+          확인
+        </Button>
+      </S.ResultPageContainer>
+    </Layout>
+  );
+};
+
+export default ResultPage;
+
+const S = {
+  ResultPageContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 50px;
+
+    margin-top: 20%;
+  `,
+
+  Message: styled.h1`
+    font-size: 30px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    text-align: center;
+
+    @media (max-width: 768px) {
+      font-size: 20px;
+    }
+  `,
+
+  Bold: styled.span`
+    font-weight: 700;
+  `,
+};

--- a/frontend/src/pages/ResultPage.tsx
+++ b/frontend/src/pages/ResultPage.tsx
@@ -12,7 +12,7 @@ const ResultPage = () => {
       <S.ResultPageContainer>
         <S.Message>
           {'리뷰 요청글 생성이 완료되었습니다.\n'}
-          <S.Bold>러너 마이페이지</S.Bold>에서 <S.Bold>서포터를 선택</S.Bold>하고 리뷰를 진행해 주세요.
+          <S.Bold>러너 마이페이지</S.Bold>에서 <S.Bold>서포터를 선택</S.Bold>하여 리뷰를 진행해 주세요.
         </S.Message>
         <Button colorTheme="WHITE" onClick={goToMyPage}>
           확인

--- a/frontend/src/pages/RunnerPostCreatePage.tsx
+++ b/frontend/src/pages/RunnerPostCreatePage.tsx
@@ -29,7 +29,7 @@ import { useFetch } from '@/hooks/useFetch';
 const RunnerPostCreatePage = () => {
   const nowDate = new Date();
 
-  const { goBack, goToMainPage } = usePageRouter();
+  const { goBack, goToResultPage } = usePageRouter();
   const { postRequestWithAuth } = useFetch();
   const { showErrorToast, showCompletionToast } = useContext(ToastContext);
 
@@ -173,7 +173,7 @@ const RunnerPostCreatePage = () => {
       async () => {
         showCompletionToast(TOAST_COMPLETION_MESSAGE.CREATE_POST);
 
-        goToMainPage();
+        goToResultPage();
       },
       body,
     );

--- a/frontend/src/pages/RunnerPostCreatePage.tsx
+++ b/frontend/src/pages/RunnerPostCreatePage.tsx
@@ -38,7 +38,7 @@ const RunnerPostCreatePage = () => {
   const [tags, setTags] = useState<string[]>([]);
   const [title, setTitle] = useState<string>('');
   const [pullRequestUrl, setPullRequestUrl] = useState<string>('');
-  const [deadline, setDeadline] = useState<string>(getDayLastTime(addDays(nowDate, 1)));
+  const [deadline, setDeadline] = useState<string>(getDayLastTime(addDays(nowDate, 10)));
   const [implementedContents, setImplementedContents] = useState<string>('');
   const [curiousContents, setCuriousContents] = useState<string>('');
   const [postscriptContents, setPostscriptContents] = useState<string>('');

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -13,6 +13,7 @@ const SupporterFeedbackPage = React.lazy(() => import('./pages/SupporterFeedback
 const SupporterProfilePage = React.lazy(() => import('./pages/SupporterProfilePage'));
 const RunnerProfilePage = React.lazy(() => import('./pages/RunnerProfilePage'));
 const NoticePage = React.lazy(() => import('./pages/NoticePage'));
+const ResultPage = React.lazy(() => import('./pages/ResultPage'));
 
 export const ROUTER_PATH = {
   MAIN: '/',
@@ -28,6 +29,7 @@ export const ROUTER_PATH = {
   SUPPORTER_FEEDBACK: '/supporter-feedback/:runnerPostId/:supporterId',
   GITHUB_CALLBACK: '/oauth/github/callback',
   NOTICE: '/notice',
+  RESULT: '/result',
 };
 
 export const router = createBrowserRouter(
@@ -80,6 +82,7 @@ export const router = createBrowserRouter(
           path: ROUTER_PATH.NOTICE,
           element: <NoticePage />,
         },
+        { path: ROUTER_PATH.RESULT, element: <ResultPage /> },
       ],
     },
   ],


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #602 

## 참고사항
- 게시글 작성 후 결과 페이지 추가 
- 결과 페이지에서 마이페이지로 이동하도록 변경
- 서포터 선택하기 버튼 비활성화로 변경
- 마감기한 기본값 수정 (10일 후)
- mockData deadline 형식에 맞게 수정

<img width="358" alt="image" src="https://github.com/woowacourse-teams/2023-baton/assets/116625502/48a7d886-8f85-4647-8962-993fa72a3538">

<img width="1223" alt="image" src="https://github.com/woowacourse-teams/2023-baton/assets/116625502/0e701f83-07c1-4d0d-aa3f-2eeeb1e10606">

<img width="381" alt="image" src="https://github.com/woowacourse-teams/2023-baton/assets/116625502/a79e5eb0-5154-4ea7-afea-2b1aa4216736">
