### PR TITLE
DB replication 적용

### DIFF
--- a/backend/baton/src/main/java/touch/baton/config/DataSourceConfig.java
+++ b/backend/baton/src/main/java/touch/baton/config/DataSourceConfig.java
@@ -1,0 +1,55 @@
+package touch.baton.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import touch.baton.infra.database.datasource.DataSourceType;
+import touch.baton.infra.database.datasource.RoutingDataSource;
+
+import javax.sql.DataSource;
+import java.util.Map;
+
+import static touch.baton.infra.database.datasource.DataSourceType.Name.REPLICA_NAME;
+import static touch.baton.infra.database.datasource.DataSourceType.Name.ROUTING_NAME;
+import static touch.baton.infra.database.datasource.DataSourceType.Name.SOURCE_NAME;
+
+@Profile("deploy")
+@Configuration
+public class DataSourceConfig {
+
+    @Qualifier(SOURCE_NAME)
+    @ConfigurationProperties(prefix = "spring.datasource.source")
+    @Bean
+    public DataSource sourceDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Qualifier(REPLICA_NAME)
+    @ConfigurationProperties(prefix = "spring.datasource.replica")
+    @Bean
+    public DataSource replicaDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Qualifier(ROUTING_NAME)
+    @Bean
+    public DataSource routingDataSource(@Qualifier(SOURCE_NAME) final DataSource sourceDataSource,
+                                        @Qualifier(REPLICA_NAME) final DataSource replicaDataSource
+    ) {
+        return RoutingDataSource.createDefaultSetting(
+                Map.of(DataSourceType.SOURCE, sourceDataSource,
+                        DataSourceType.REPLICA, replicaDataSource)
+        );
+    }
+
+    @Bean
+    @Primary
+    public DataSource dataSource(@Qualifier(ROUTING_NAME) final DataSource replicationRoutingDataSource) {
+        return new LazyConnectionDataSourceProxy(replicationRoutingDataSource);
+    }
+}

--- a/backend/baton/src/main/java/touch/baton/infra/database/datasource/DataSourceType.java
+++ b/backend/baton/src/main/java/touch/baton/infra/database/datasource/DataSourceType.java
@@ -1,0 +1,24 @@
+package touch.baton.infra.database.datasource;
+
+import static touch.baton.infra.database.datasource.DataSourceType.Name.REPLICA_NAME;
+import static touch.baton.infra.database.datasource.DataSourceType.Name.SOURCE_NAME;
+
+public enum DataSourceType {
+
+    SOURCE(SOURCE_NAME),
+    REPLICA(REPLICA_NAME);
+
+    private final String name;
+
+    DataSourceType(final String name) {
+        this.name = name;
+    }
+
+    public static class Name {
+
+        public static final String ROUTING_NAME = "ROUTING";
+        public static final String SOURCE_NAME = "SOURCE";
+        public static final String REPLICA_NAME = "REPLICA";
+    }
+
+}

--- a/backend/baton/src/main/java/touch/baton/infra/database/datasource/RoutingDataSource.java
+++ b/backend/baton/src/main/java/touch/baton/infra/database/datasource/RoutingDataSource.java
@@ -1,0 +1,27 @@
+package touch.baton.infra.database.datasource;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.Map;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+    public static RoutingDataSource createDefaultSetting(final Map<Object, Object> dataSources) {
+        final RoutingDataSource routingDataSource = new RoutingDataSource();
+        routingDataSource.setDefaultTargetDataSource(dataSources.get(DataSourceType.SOURCE));
+        routingDataSource.setTargetDataSources(dataSources);
+        return routingDataSource;
+    }
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        final boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+
+        if (readOnly) {
+            return DataSourceType.REPLICA;
+        }
+
+        return DataSourceType.SOURCE;
+    }
+}


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #627 

## 참고사항
*  DB 백업 및 복제

<br/>

아래 명령어로 dump.sql를 만들어서 복제를 해줬습니다. 이 파일을 scp 를 이용해 replica ec2로 보냈습니다. 

<br/>

```sql
mysqldump -u root -p -v --databases <DATABASE_NAME> \
--quick --single-transaction --routines --set-gtid-purged=ON \
--triggers --extended-insert --source-data=2 > dump.sql
```

*  DB source, replica 설정
/etc/my.cnf 파일에 아래처럼 각각 설정해주었습니다.
복제 방식은 바이너리 기반과 GTID 기반이 있는데, GTID기반으로 사용했습니다.
<br/>
[이유]
1. 바이너리 기반은 복제가 중간에 중지가 되면 복구하기가 어렵다
    - 바이너리로그는 `이름 + 저장 위치`로 구별되므로 복제가 중단되면 어디부터 시작되는지 모른다고 합니다.
2. 설정방법이 차이가 별로 없다.

```sql
# Replication - Source
server-id=1
log-bin=binlog
gtid-mode=ON
enforce-gtid-consistency=ON
```

<br/>

```sql
# Replication - Replica
server-id=2
log-bin=binlog 
gtid-mode=ON # GTID 모드
enforce-gtid-consistency=ON # GTID 모드
relay_log=mysql-relay-bin
relay_log_purge=ON # rela_log 자동 삭제
read_only # 읽기 전용 DB로 사용
super_read_only # Replica에서 root도 dml이나 ddl을 실행할 수 없음
log_replica_updates=ON # 복제된 내용을 자신의 바이너리 로그에 저장(추후에 승급되면 사용 가능)
```

*  스프링 요청에서 DataSource 분리
[참고사항]

```java
@Profile("deploy")
@Configuration
public class DataSourceConfig {

// …
    @Bean
    @Primary
    public DataSource dataSource(@Qualifier(ROUTING_NAME) final DataSource replicationRoutingDataSource) {
        return new LazyConnectionDataSourceProxy(replicationRoutingDataSource);
    }
}
```
<br/>
원래 Transaction이 시작되면 connection이 시작되는데 lazyConnectionDataSourceProxy를 사용해서 sql을 실행하기 직전까지 connection을 가져오는것을 미룹니다(readonly 설정이 설정된 뒤에 가져오기 위해서인 듯)

```java
public class RoutingDataSource extends AbstractRoutingDataSource {

    public static RoutingDataSource createDefaultSetting(final Map<Object, Object> dataSources) {
        final RoutingDataSource routingDataSource = new RoutingDataSource();
        routingDataSource.setDefaultTargetDataSource(dataSources.get(DataSourceType.SOURCE));
        routingDataSource.setTargetDataSources(dataSources);
        return routingDataSource;
    }

    @Override
    protected Object determineCurrentLookupKey() {
        final boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();

        if (readOnly) {
            return DataSourceType.REPLICA;
        }

        return DataSourceType.SOURCE;
    }
}
```

AbstractRoutingDataSource를 상속받아서 determineCurrentLookupKey를 override해줬는데 여기서 transaction이 readonly인지 boolean으로 반환해서 datasource를 replica나 source로 보내줍니다.

참고 : [후디](https://hudi.blog/database-replication-with-springboot-and-mysql/), [허브](https://greeng00se.github.io/db-replication), [공식문서](https://dev.mysql.com/doc/refman/8.0/en/replication-options-gtids.html#sysvar_enforce_gtid_consistency)

**ps 블로그에 더 이쁘게 해서 올릴게요**