### PR TITLE
Nginx와 Spring 로그가 같은 식별자값을 가지도록 수정

### DIFF
--- a/backend/baton/src/main/java/touch/baton/config/filter/FilterConfig.java
+++ b/backend/baton/src/main/java/touch/baton/config/filter/FilterConfig.java
@@ -15,7 +15,7 @@ public class FilterConfig implements WebMvcConfigurer {
     public FilterRegistrationBean<Filter> getFilterRegistrationBean() {
         final FilterRegistrationBean<Filter> registrationBean = new FilterRegistrationBean<>(new MDCLoggingFilter());
         registrationBean.setOrder(Integer.MIN_VALUE);
-        registrationBean.setUrlPatterns(List.of("/api/**"));
+        registrationBean.setUrlPatterns(List.of("/api/*"));
         return registrationBean;
     }
 }

--- a/backend/baton/src/main/java/touch/baton/config/filter/MDCLoggingFilter.java
+++ b/backend/baton/src/main/java/touch/baton/config/filter/MDCLoggingFilter.java
@@ -5,6 +5,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.core.config.Order;
 import org.slf4j.MDC;
 import org.springframework.core.Ordered;
@@ -17,8 +19,9 @@ class MDCLoggingFilter implements Filter {
 
     @Override
     public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse, final FilterChain filterChain) throws IOException, ServletException {
-        final UUID uuid = UUID.randomUUID();
-        MDC.put("request_id", uuid.toString());
+        final String requestId = ((HttpServletRequest) servletRequest).getHeader("X-Request-ID");
+
+        MDC.put("request_id", StringUtils.defaultString(requestId, UUID.randomUUID().toString()));
         filterChain.doFilter(servletRequest, servletResponse);
         MDC.clear();
     }


### PR DESCRIPTION
## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- resolved #651
## 참고사항
Nginx와 Spring 로그가 같은 식별자값을 가지도록 수정하도록 변경했습니다.

```
log_format  main  '[$request_id] $remote_addr - $remote_user [$time_local] "$request" '
                  '$status $body_bytes_sent "$http_referer" "$request_time" '
                  '"$http_user_agent" "$http_x_forwarded_for"'
                  '"$ssl_protocol/$ssl_cipher" "$content_length"'
                  '"$request_length"' ;
```

를 `/etc/nginx/sites-available/client`에 설정을 추가해서 requestId를 log에서 사용하도록 했습니다.

```
proxy_set_header X-Request-ID $request_id;
access_log /var/log/nginx/access.log main; # Log $request_id
```

서버블록에는 이 두 개를 추가해서 request_id를  헤더로 스프링에게 전해주도록하고 필터에서 받아서 사용합니다.
로컬같은 경우를 위해서 UUID는 남겨놨습니다. 
